### PR TITLE
Add multiple layouts and a commands to switch the current layout

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -28,6 +28,7 @@ const command = struct {
     const focusAllTags = @import("command/focus_all_tags.zig").focusAllTags;
     const focusOutput = @import("command/focus_output.zig").focusOutput;
     const focusTag = @import("command/focus_tag.zig").focusTag;
+    const layout = @import("command/layout.zig").layout;
     const modMasterCount = @import("command/mod_master_count.zig").modMasterCount;
     const modMasterFactor = @import("command/mod_master_factor.zig").modMasterFactor;
     const mode = @import("command/mode.zig").mode;
@@ -101,6 +102,7 @@ const str_to_read_fn = [_]Definition{
     .{ .name = "focus_all_tags",    .arg_type = .none,      .impl = command.focusAllTags },
     .{ .name = "focus_output",      .arg_type = .direction, .impl = command.focusOutput },
     .{ .name = "focus_tag",         .arg_type = .uint,      .impl = command.focusTag },
+    .{ .name = "layout",            .arg_type = .str,       .impl = command.layout},
     .{ .name = "mod_master_count",  .arg_type = .int,       .impl = command.modMasterCount },
     .{ .name = "mod_master_factor", .arg_type = .float,     .impl = command.modMasterFactor },
     .{ .name = "mode",              .arg_type = .str,       .impl = command.mode },

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -211,6 +211,35 @@ pub fn init(self: *Self, allocator: *std.mem.Allocator) !void {
         .command = try Command.init(&[_][]const u8{ "mode", "normal" }, allocator),
     });
 
+    // Change master orientation with Mod+{Up,Right,Down,Left}
+    try normal.keybinds.append(.{
+        .keysym = c.XKB_KEY_Up,
+        .modifiers = mod,
+        .command = try Command.init(&[_][]const u8{ "layout", "TopMaster" }, allocator),
+    });
+    try normal.keybinds.append(.{
+        .keysym = c.XKB_KEY_Right,
+        .modifiers = mod,
+        .command = try Command.init(&[_][]const u8{ "layout", "RightMaster" }, allocator),
+    });
+    try normal.keybinds.append(.{
+        .keysym = c.XKB_KEY_Down,
+        .modifiers = mod,
+        .command = try Command.init(&[_][]const u8{ "layout", "BottomMaster" }, allocator),
+    });
+    try normal.keybinds.append(.{
+        .keysym = c.XKB_KEY_Left,
+        .modifiers = mod,
+        .command = try Command.init(&[_][]const u8{ "layout", "LeftMaster" }, allocator),
+    });
+
+    // Mod+f to change to Full layout
+    try normal.keybinds.append(.{
+        .keysym = c.XKB_KEY_f,
+        .modifiers = mod,
+        .command = try Command.init(&[_][]const u8{ "layout", "Full" }, allocator),
+    });
+
     // Float views with app_id "float"
     try self.float_filter.append("float");
 }

--- a/src/Output.zig
+++ b/src/Output.zig
@@ -384,6 +384,16 @@ pub fn arrangeViews(self: *Self) void {
         break :blk count;
     };
 
+    // A single view should always use the maximum available space. This is
+    // implemented via the "full" layout to remove the need of every single
+    // layout to explicitly handle this edge case or the other edge case of
+    // no visible views.
+    if (visible_count <= 1) {
+        layoutFull(self, visible_count, output_tags);
+        return;
+    }
+
+    // TODO layout switching mechanism
     //layoutFull(self, visible_count, output_tags);
     //layoutTopMaster(self, visible_count, output_tags);
     //layoutRightMaster(self, visible_count, output_tags);

--- a/src/Output.zig
+++ b/src/Output.zig
@@ -52,10 +52,22 @@ master_count: u32,
 /// Percentage of the total screen that the master section takes up.
 master_factor: f64,
 
+/// Current layout of the output.
+layout: Layouts,
+
 // All listeners for this output, in alphabetical order
 listen_destroy: c.wl_listener,
 listen_frame: c.wl_listener,
 listen_mode: c.wl_listener,
+
+// All possible layouts.
+pub const Layouts = enum {
+    TopMaster,
+    RightMaster,
+    BottomMaster,
+    LeftMaster,
+    Full,
+};
 
 pub fn init(self: *Self, root: *Root, wlr_output: *c.wlr_output) !void {
     // Some backends don't have modes. DRM+KMS does, and we need to set a mode
@@ -91,6 +103,9 @@ pub fn init(self: *Self, root: *Root, wlr_output: *c.wlr_output) !void {
     self.master_count = 1;
 
     self.master_factor = 0.6;
+
+    // LeftMaster is the default layout for all outputs
+    self.layout = Layout.LeftMaster;
 
     // Set up listeners
     self.listen_destroy.notify = handleDestroy;
@@ -393,13 +408,13 @@ pub fn arrangeViews(self: *Self) void {
         return;
     }
 
-    // TODO layout switching mechanism
-    //layoutFull(self, visible_count, output_tags);
-    //layoutTopMaster(self, visible_count, output_tags);
-    //layoutRightMaster(self, visible_count, output_tags);
-    //layoutBottomMaster(self, visible_count, output_tags);
-    //layoutLeftMaster(self, visible_count, output_tags);
-    layoutFull(self, visible_count, output_tags);
+    switch (self.layout) {
+        .Full => layoutFull(self, visible_count, output_tags),
+        .TopMaster => layoutTopMaster(self, visible_count, output_tags),
+        .RightMaster => layoutRightMaster(self, visible_count, output_tags),
+        .BottomMaster => layoutBottomMaster(self, visible_count, output_tags),
+        .LeftMaster => layoutLeftMaster(self, visible_count, output_tags),
+    }
 }
 
 /// Arrange all layer surfaces of this output and addjust the usable aread

--- a/src/Output.zig
+++ b/src/Output.zig
@@ -53,7 +53,7 @@ master_count: u32,
 master_factor: f64,
 
 /// Current layout of the output.
-layout: Layouts,
+layout: Layout,
 
 // All listeners for this output, in alphabetical order
 listen_destroy: c.wl_listener,
@@ -61,13 +61,39 @@ listen_frame: c.wl_listener,
 listen_mode: c.wl_listener,
 
 // All possible layouts.
-pub const Layouts = enum {
+pub const Layout = enum {
     TopMaster,
     RightMaster,
     BottomMaster,
     LeftMaster,
     Full,
 };
+
+const LayoutName = struct {
+    name: []const u8,
+    layout: Layout,
+};
+
+// zig fmt: off
+const layout_names = [_]LayoutName {
+    .{ .name = "TopMaster",    .layout = Layout.TopMaster, },
+    .{ .name = "RightMaster",  .layout = Layout.RightMaster, },
+    .{ .name = "BottomMaster", .layout = Layout.BottomMaster, },
+    .{ .name = "LeftMaster",   .layout = Layout.LeftMaster, },
+    .{ .name = "Full",         .layout = Layout.Full, },
+};
+// zig fmt: on
+
+pub fn getLayoutByName(self: Self, name: []const u8) Layout {
+    for (layout_names) |current| {
+        if (std.mem.eql(u8, name, current.name)) {
+            return current.layout;
+        }
+    }
+    Log.Error.log("Layout '{}' does not exist", .{name});
+    // In case of error default to LeftMaster
+    return Layout.LeftMaster;
+}
 
 pub fn init(self: *Self, root: *Root, wlr_output: *c.wlr_output) !void {
     // Some backends don't have modes. DRM+KMS does, and we need to set a mode

--- a/src/Output.zig
+++ b/src/Output.zig
@@ -323,6 +323,40 @@ pub fn layoutLeftMaster(self: *Self, visible_count: u32, output_tags: u32) void 
     layoutMasterStack(self, visible_count, output_tags, MasterPosition.Left);
 }
 
+/// A layout in which every window uses the maximum available space.
+pub fn layoutFull(self: *Self, visible_count: u32, output_tags: u32) void {
+    const border_width = self.root.server.config.border_width;
+    const outer_padding = self.root.server.config.outer_padding;
+
+    const layout_width = @intCast(u32, self.usable_box.width)
+            - (outer_padding * 2) - (border_width * 2);
+    const layout_height = @intCast(u32, self.usable_box.height)
+            - (outer_padding * 2) - (border_width * 2);
+    const xy_offset = @intCast(i32, outer_padding + border_width);
+
+    var i: u32 = 0;
+    var it = ViewStack(View).pendingIterator(self.views.first, output_tags);
+    while (it.next()) |node| {
+        const view = &node.view;
+
+        if (view.floating) {
+            continue;
+        }
+
+        var new_box: Box = undefined;
+        new_box = .{
+            .x = xy_offset,
+            .y = xy_offset,
+            .width = layout_width,
+            .height = layout_height,
+        };
+
+        view.pending_box = new_box;
+
+        i += 1;
+    }
+}
+
 /// Arrange all views on the output for the current layout. Modifies only
 /// pending state, the changes are not appplied until a transaction is started
 /// and completed.
@@ -354,7 +388,8 @@ pub fn arrangeViews(self: *Self) void {
     //layoutTopMaster(self, visible_count, output_tags);
     //layoutRightMaster(self, visible_count, output_tags);
     //layoutBottomMaster(self, visible_count, output_tags);
-    layoutLeftMaster(self, visible_count, output_tags);
+    //layoutLeftMaster(self, visible_count, output_tags);
+    layoutFull(self, visible_count, output_tags);
 }
 
 /// Arrange all layer surfaces of this output and addjust the usable aread

--- a/src/command/layout.zig
+++ b/src/command/layout.zig
@@ -1,0 +1,29 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2020 Leon Henrik Plickat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const c = @import("../c.zig");
+
+const Arg = @import("../Command.zig").Arg;
+const Seat = @import("../Seat.zig");
+
+pub fn layout(seat: *Seat, arg: Arg) void {
+    const layout_name = arg.str;
+    const config = seat.input_manager.server.config;
+    seat.focused_output.layout = seat.focused_output.getLayoutByName(layout_name);
+    seat.focused_output.arrangeViews();
+    seat.input_manager.server.root.startTransaction();
+}


### PR DESCRIPTION
This PR adds multiple layouts to river.

State:

* [X] Layouts
  * [X] Full
  * [X] Top master
  * [X] Right master
  * [X] Bottom  master
  * [X] left master
* [x] Switching mechanism
  * [X] Automatically use "full" for one or no visible views
  * [X] Add `layout` variable to `Output` class to control which layout gets chosen in `arrangeViews()`
  * [X] Add `layout` variable to `Config` class to control the default layout of new outputs
  * [X] Set `LeftMaster` as the default layout
  * [x] Add command to change the layout of the focused output
  * [x] Add command to change the default layout of new outputs