### PR TITLE
[WIP] External layouts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -211,6 +211,7 @@ const ScdocStep = struct {
     const scd_paths = [_][]const u8{
         "doc/river.1.scd",
         "doc/riverctl.1.scd",
+        "doc/river-layouts.1.scd",
     };
 
     builder: *std.build.Builder,

--- a/contrib/random-correct-layout.sh
+++ b/contrib/random-correct-layout.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Randomized Layout for debug purposes.
+
+CLIENTS="$1"
+OUTPUT_WIDTH="$4"
+OUTPUT_HEIGHT="$5"
+
+for _ in $(seq 1 "$CLIENTS")
+do
+	WIDTH="$(( ( OUTPUT_WIDTH  / 5 ) ))"
+	HEIGHT="$(( ( OUTPUT_HEIGHT  / 5 ) ))"
+	X="$(( ( RANDOM % ( OUTPUT_WIDTH  - WIDTH  ) )  + 1 ))"
+	Y="$(( ( RANDOM % ( OUTPUT_HEIGHT - HEIGHT ) )  + 1 ))"
+	echo "$X $Y $WIDTH $HEIGHT"
+done
+

--- a/contrib/random-incorrect-layout.sh
+++ b/contrib/random-incorrect-layout.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Randomized Layout for debug purposes. This version randomly makes some errors
+# see how river handles incorrect output of layout executables.
+
+CLIENTS="$1"
+OUTPUT_WIDTH="$4"
+OUTPUT_HEIGHT="$5"
+
+for _ in $(seq 1 "$CLIENTS")
+do
+	WIDTH="$(( ( OUTPUT_WIDTH  / 5 ) ))"
+	HEIGHT="$(( ( OUTPUT_HEIGHT  / 5 ) ))"
+	X="$(( ( RANDOM % ( OUTPUT_WIDTH  - WIDTH  ) )  + 1 ))"
+	Y="$(( ( RANDOM % ( OUTPUT_HEIGHT - HEIGHT ) )  + 1 ))"
+
+	# Mix in some errors
+	case "$(( ( RANDOM % 10 ) ))" in
+		0) # Too few layout rows
+			;;
+
+		1) # Too many layout rows
+			echo "$X $Y $WIDTH $HEIGHT"
+			echo "$X $Y $WIDTH $HEIGHT"
+			;;
+
+		2) # Too few layout columns
+			echo "$X $Y $WIDTH"
+			;;
+
+		3) # Too many layout columns
+			echo "$X $Y $WIDTH $HEIGHT $X"
+			;;
+
+
+		4) # Negative view size
+			echo "$X $Y -$WIDTH $HEIGHT $X"
+			;;
+
+		*) # Expected behaviour
+			echo "$X $Y $WIDTH $HEIGHT"
+			;;
+	esac
+done
+

--- a/doc/river-layouts.1.scd
+++ b/doc/river-layouts.1.scd
@@ -1,0 +1,74 @@
+RIVER-LAYOUTS(7) "github.com/ifreund/river"
+
+# NAME
+river-layouts - Details on layout generators for river
+
+# DESCRIPTION
+River can use external window management layouts. To get such a layout, river
+will run an executable and parse its output. This document outlines how such
+a layout generator interacts with river.
+
+# INPUT
+When running the executable, river will provide it with five parameters which
+are appended to the end of the command in the following order:
+
+. The amount of visible clients (integer)
+. The amount of views dedicated as master (integer)
+. The screen size multiplier for the master area (float between 0.0 and 1.0)
+. The useable width of the output (integer)
+. The useable height of the output (integer)
+
+A layout generator may choose to ignore any of these values except
+for the first one.
+
+# OUTPUT
+River expects four integer values for each window: The x position, the y
+position, the width and the height. These must be separated by spaces. A
+window configuration having fewer or more than four values is an error and will
+cause river to fall back the full layout.
+
+A layout generator needs to output position and size for every visible window.
+The window configurations are separated by a newline. Too few or too many
+outputted window configurations is an error and will cause river to fall back
+to the full layout.
+
+River will apply the position and dimensions in the order they are outputted to
+the visible windows in the stack from top to bottom.
+
+The output of a layout generator is not required to remain the same when called
+with identical parameters. Layouts are allowed to also depend on external
+factors or be completely random.
+
+# WINDOW DIMENSIONS and POSITION
+Layout generators are not supposed to include padding or leave space for window
+borders. The window dimensions will be shrunk by river to make space for these.
+River enforces a minimal window width and height of 50.
+
+Layout generators operate on a special coordinate grid from 0 to the maximum
+useable width or height of an output with the coordinate 0-0 being positioned at
+the top-left corner of the useable area of an output. While layout generators
+are free to place windows everywhere (including coordinates below zero or above
+the maximum width or height of an output), beware that the relative positioning
+of this grid on the screen can not be expected to remain constant. River applies
+an offset to window positions, depending on outer padding and the presence of
+desktop widgets like bars. Layout generators can therefore not position windows
+at exact screen coordinates.
+
+Layout generators are not required to make use of the entire available space.
+Windows may overlap.
+
+# EXAMPLE
+Below is an example output of a layout generator for four visible windows. In
+this example layout all four windows have a size of 500 by 500 and are arranged
+in a grid.
+
+```
+0 0 500 500
+500 0 500 500
+0 500 500 500
+500 500 500 500
+```
+
+# SEE ALSO
+*river*(1), *riverctl*(1)
+

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -31,8 +31,13 @@ used to control and configure river.
 *focus-view* *next*|*previous*
 	Focus next or previous view in the stack.
 
-*layout* *top-master*|*right-master*|*bottom-master*|*left-master*|*full*
-	Change the view layout.
+*layout* *full*|_command_
+	Provide a command which river will use for generating the layout of
+	non-floating windows on the currently focused output. See
+	*river-layouts*(1) for details on the expected formatting of the output
+	of layout commands. Alternatively, "full"can be given instead of a
+	command to cause river to use its single internal layout, in which
+	windows span the entire width and height of the output.
 
 *mod-master-count* _integer_
 	Increase or decrease the number of master views. _integer_ can be

--- a/river/command/layout.zig
+++ b/river/command/layout.zig
@@ -29,9 +29,10 @@ pub fn layout(
     failure_message: *[]const u8,
 ) Error!void {
     if (args.len < 2) return Error.NotEnoughArguments;
-    if (args.len > 2) return Error.TooManyArguments;
 
-    seat.focused_output.layout = seat.focused_output.getLayoutByName(args[1]);
+    allocator.free(seat.focused_output.layout);
+    seat.focused_output.layout = try std.mem.join(allocator, " ", args[1..]);
+
     seat.focused_output.arrangeViews();
     seat.input_manager.server.root.startTransaction();
 }


### PR DESCRIPTION
This is not even remotely finished yet, but I'll park it here anyway so I have a place to brain-dump.

Progress:
* [X] Remove `layoutMasterStack()`
* [X] Refactor `layoutFull()`
  * [X] Minimal window size
* [x] layout switching
  * [X] simplify `arrangeViews()`
  * [X] fallback to `layoutFull()` when `layoutExternal()` fails.
  * [x] Find a sane way to set and store the path to the layout executable as well as possible commands flags to it (which I think are required; example: `riverctl layout ~/my-fancy-layout --master-top`)
  * [x] Change layout command
* [x] `layoutExternal()`
  * [X] create command
  * [X] execute layout executable
  * [x] catch output in buffer
  * [x] Parse buffer
  * [X] apply to views
  * [X] Offset, shrinking, minimal window size
* [x] Write documentation
* [x] Cleanup commit history

The biggest hurdle by far is definitely the zig standard library not being documented.

A big problem for users will be, that river will halt while the layout executable is running. This is fine for now, but before version 1.0 it should probably be made async somehow, so that a faulty layout executable does not block the entire system, requiring a restart or Sysrq magic. Or instead of async, just abort after an arbitrary amount of time (like 1 second) and fall back to `layoutFull()`.