### PR TITLE
command: Added border_focused_color and border_unfocused_color options

### DIFF
--- a/doc/riverctl.1
+++ b/doc/riverctl.1
@@ -170,6 +170,10 @@ List of valid options:
 .IP 	\(bu
 border_width (non-negative integer)
 .IP 	\(bu
+border_focused_color (RGB hex code)
+.IP 	\(bu
+border_unfocused_color (RGB hex code)
+.IP 	\(bu
 outer_padding (non-negative integer)
 
 .SH EXAMPLES

--- a/river/Config.zig
+++ b/river/Config.zig
@@ -23,10 +23,17 @@ const c = @import("c.zig");
 
 const Log = @import("log.zig").Log;
 const Server = @import("Server.zig");
+const Rgb = @import("Rgb.zig");
 const Mapping = @import("Mapping.zig");
 
 /// Width of borders in pixels
 border_width: u32,
+
+/// Color of border of focused window in RGB
+border_focused_color: Rgb,
+
+/// Color of border of unfocused window in RGB
+border_unfocused_color: Rgb,
 
 /// Amount of view padding in pixels
 view_padding: u32,
@@ -45,6 +52,8 @@ float_filter: std.ArrayList([*:0]const u8),
 
 pub fn init(self: *Self, allocator: *std.mem.Allocator) !void {
     self.border_width = 2;
+    try self.border_focused_color.parseString("#93A1A1"); // Solarized base1
+    try self.border_unfocused_color.parseString("#586E75"); // Solarized base0
     self.view_padding = 8;
     self.outer_padding = 8;
 

--- a/river/Control.zig
+++ b/river/Control.zig
@@ -126,6 +126,7 @@ fn runCommand(
                     command.Error.Overflow => "value out of bounds",
                     command.Error.InvalidCharacter => "invalid character in argument",
                     command.Error.InvalidDirection => "invalid direction. Must be 'next' or 'previous'",
+                    command.Error.InvalidRgbFormat => "invalid RGB format",
                     command.Error.OutOfMemory => "out of memory",
                     command.Error.CommandFailed => unreachable,
                 },

--- a/river/Rgb.zig
+++ b/river/Rgb.zig
@@ -1,0 +1,45 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2020 Rishabh Das
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const Self = @This();
+
+const std = @import("std");
+
+r: u8,
+g: u8,
+b: u8,
+
+pub fn parseString(self: *Self, string: []const u8) !void {
+    if (string[0] != '#' or string.len != 7) return error.InvalidRgbFormat;
+
+    const r = try std.fmt.parseInt(u8, string[1..3], 16);
+    const g = try std.fmt.parseInt(u8, string[3..5], 16);
+    const b = try std.fmt.parseInt(u8, string[5..7], 16);
+
+    self.r = r;
+    self.g = g;
+    self.b = b;
+}
+
+pub fn getDecimalRgbaArray(self: Self) [4]f32 {
+    return [4]f32{
+        @intToFloat(f32, self.r) / 255.0,
+        @intToFloat(f32, self.g) / 255.0,
+        @intToFloat(f32, self.b) / 255.0,
+        1.0,
+    };
+}

--- a/river/command.zig
+++ b/river/command.zig
@@ -57,11 +57,17 @@ pub const Direction = enum {
 
 pub const Option = enum {
     BorderWidth,
+    BorderFocusedColor,
+    BorderUnfocusedColor,
     OuterPadding,
 
     pub fn parse(str: []const u8) error{UnknownOption}!Option {
         return if (std.mem.eql(u8, str, "border_width"))
             Option.BorderWidth
+        else if (std.mem.eql(u8, str, "border_focused_color"))
+            Option.BorderFocusedColor
+        else if (std.mem.eql(u8, str, "border_unfocused_color"))
+            Option.BorderUnfocusedColor
         else if (std.mem.eql(u8, str, "outer_padding"))
             Option.OuterPadding
         else
@@ -105,6 +111,7 @@ pub const Error = error{
     Overflow,
     InvalidCharacter,
     InvalidDirection,
+    InvalidRgbFormat,
     UnknownOption,
     OutOfMemory,
     CommandFailed,

--- a/river/command/set_option.zig
+++ b/river/command/set_option.zig
@@ -31,14 +31,17 @@ pub fn setOption(
     if (args.len < 3) return Error.NotEnoughArguments;
     if (args.len > 3) return Error.TooManyArguments;
 
+    const config = &seat.focused_output.root.server.config;
+
     // Parse option and value.
     const option = try Option.parse(args[1]);
-    const value = try std.fmt.parseInt(u32, args[2], 10);
 
     // Assign value to option.
     switch (option) {
-        .BorderWidth => seat.focused_output.root.server.config.border_width = value,
-        .OuterPadding => seat.focused_output.root.server.config.outer_padding = value,
+        .BorderWidth => config.border_width = try std.fmt.parseInt(u32, args[2], 10),
+        .BorderFocusedColor => try config.border_focused_color.parseString(args[2]),
+        .BorderUnfocusedColor => try config.border_unfocused_color.parseString(args[2]),
+        .OuterPadding => config.outer_padding = try std.fmt.parseInt(u32, args[2], 10),
     }
 
     // 'Refresh' focused output to display the desired changes.

--- a/river/render.zig
+++ b/river/render.zig
@@ -240,9 +240,9 @@ fn renderTexture(
 fn renderBorders(output: Output, view: *View, now: *c.timespec) void {
     var border: Box = undefined;
     const color = if (view.focused)
-        [_]f32{ 0.57647059, 0.63137255, 0.63137255, 1.0 } // Solarized base1
+        output.root.server.config.border_focused_color.getDecimalRgbaArray()
     else
-        [_]f32{ 0.34509804, 0.43137255, 0.45882353, 1.0 }; // Solarized base01
+        output.root.server.config.border_unfocused_color.getDecimalRgbaArray();
     const border_width = output.root.server.config.border_width;
 
     // left and right, covering the corners as well


### PR DESCRIPTION
Implements #43. Hex code is required to be enclosed in double quotes.
```
riverctl set-option border_focused_color "#a1a1a1"
```