### PR TITLE
Implement moving views via cursor

### DIFF
--- a/river/Keyboard.zig
+++ b/river/Keyboard.zig
@@ -155,6 +155,9 @@ fn handleModifiers(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) void 
         self.seat.wlr_seat,
         &self.wlr_keyboard.modifiers,
     );
+
+    const modifiers = c.wlr_keyboard_get_modifiers(self.wlr_keyboard);
+    self.seat.pointer_modifier = modifiers == c.WLR_MODIFIER_LOGO;
 }
 
 /// Handle any builtin, harcoded compsitor mappings such as VT switching.

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -70,6 +70,9 @@ focused_layer: ?*LayerSurface,
 /// List of status tracking objects relaying changes to this seat to clients.
 status_trackers: std.SinglyLinkedList(SeatStatus),
 
+/// State of pointer modifier; Used for pointer operations such as move ans resize.
+pointer_modifier: bool,
+
 listen_request_set_selection: c.wl_listener,
 
 pub fn init(self: *Self, input_manager: *InputManager, name: [*:0]const u8) !void {
@@ -95,6 +98,8 @@ pub fn init(self: *Self, input_manager: *InputManager, name: [*:0]const u8) !voi
     self.focused_layer = null;
 
     self.status_trackers = std.SinglyLinkedList(SeatStatus).init();
+
+    self.pointer_modifier = false;
 
     self.listen_request_set_selection.notify = handleRequestSetSelection;
     c.wl_signal_add(&self.wlr_seat.events.request_set_selection, &self.listen_request_set_selection);

--- a/river/c.zig
+++ b/river/c.zig
@@ -21,6 +21,7 @@ pub usingnamespace @cImport({
 
     @cInclude("time.h");
     @cInclude("stdlib.h");
+    @cInclude("linux/input-event-codes.h");
     @cInclude("wayland-server-core.h");
     //@cInclude("wlr/backend.h");
     //@cInclude("wlr/render/wlr_renderer.h");


### PR DESCRIPTION
As discussed in IRC.

This is supposed to work similar to dwm: Trying to move a window will float it. I ended up implementing cursor warp, because it actually simplifies things a bit; I can remove it later though if desired..

TODO:
* [X] Moving logic
  * [X] Enter move mode
  * [X] Leave move mode
  * [X] Handle cursor events when in move mode
  * [X] Make it easy to implement pointer resizing and other mouse operations in the future
* [X] Add `pointer_modifier: bool` to seat, to track whether the pointer modifier(s) are currently pressed.
* [x] Seat `pointer_modifer` when correct modifier key has been pressed.
* [ ] ~~Implement way to configure modifier key.~~

As it is now, this PR contains some C-like stuff I have to zig-ify first before it can be tested.  Also it might be a good idea to investigate whether function pointers instead of switches in cursor event handling code are more efficient.