### PR TITLE
docs: Fix duplicate mapping in config.sh

### DIFF
--- a/contrib/config.sh
+++ b/contrib/config.sh
@@ -63,7 +63,7 @@ riverctl map normal $mod+Shift 0 set-view-tags $all_tags_mask
 riverctl map normal $mod Space toggle-float
 
 # Mod+F to toggle fullscreen
-riverctl map normal $mod Space toggle-fullscreen
+riverctl map normal $mod F toggle-fullscreen
 
 # Mod+{Up,Right,Down,Left} to change master orientation
 riverctl map normal $mod Up layout rivertile top


### PR DESCRIPTION
You should also consider renaming the full layout to _monocle_ or _single_ to match the new default mapping.