### PR TITLE
cursor: close view on middleclick when pointer_modifier is active

### DIFF
--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -246,12 +246,12 @@ fn handleButton(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) void {
 
                 if (event.state == .WLR_BUTTON_PRESSED) {
                     // If the button is pressed and the pointer modifier is
-                    // active, enter cursor mode and return.
+                    // active, enter cursor mode or close view and return.
                     if (self.seat.pointer_modifier) {
                         switch (event.button) {
                             c.BTN_LEFT => enterCursorMode(self, event, view, CursorMode.Move),
+                            c.BTN_MIDDLE => view.close(),
                             c.BTN_RIGHT => {}, // TODO Resize
-                            c.BTN_MIDDLE => {}, // TODO Some useful operation, maybe kill
 
                             // TODO Some mice have additional buttons. These
                             // could also be bound to some useful action.


### PR DESCRIPTION
When a user is interacting with (possible floating) views via the pointer, they may want to close a view that way as well.

The middle mouse button is not something you'd click accidentally, especially when a modifier key is also pressed, so I think this has no drawbacks, not even code complexity, as it is literally a single line.