### PR TITLE
Implement csd_filter list

### DIFF
--- a/river/Config.zig
+++ b/river/Config.zig
@@ -52,6 +52,9 @@ modes: std.ArrayList(std.ArrayList(Mapping)),
 /// List of app_ids which will be started floating
 float_filter: std.ArrayList([*:0]const u8),
 
+/// List of app_ids which are allowed to use client side decorations
+csd_filter: std.ArrayList([]const u8),
+
 pub fn init(self: *Self) !void {
     self.background_color = [_]f32{ 0.0, 0.16862745, 0.21176471, 1.0 }; // Solarized base03
     self.border_width = 2;
@@ -73,8 +76,14 @@ pub fn init(self: *Self) !void {
     self.float_filter = std.ArrayList([*:0]const u8).init(util.gpa);
     errdefer self.float_filter.deinit();
 
+    self.csd_filter = std.ArrayList([]const u8).init(util.gpa);
+    errdefer self.csd_filter.deinit();
+
     // Float views with app_id "float"
     try self.float_filter.append("float");
+
+    // Client side decorations for views with app_id "csd"
+    try self.csd_filter.append("csd");
 }
 
 pub fn deinit(self: Self) void {
@@ -89,4 +98,5 @@ pub fn deinit(self: Self) void {
     self.modes.deinit();
 
     self.float_filter.deinit();
+    self.csd_filter.deinit();
 }

--- a/river/DecorationManager.zig
+++ b/river/DecorationManager.zig
@@ -25,6 +25,8 @@ const util = @import("util.zig");
 const Decoration = @import("Decoration.zig");
 const Server = @import("Server.zig");
 
+server: *Server,
+
 wlr_xdg_decoration_manager: *c.wlr_xdg_decoration_manager_v1,
 
 decorations: std.SinglyLinkedList(Decoration),
@@ -34,6 +36,8 @@ listen_new_toplevel_decoration: c.wl_listener,
 pub fn init(self: *Self, server: *Server) !void {
     self.wlr_xdg_decoration_manager = c.wlr_xdg_decoration_manager_v1_create(server.wl_display) orelse
         return error.OutOfMemory;
+
+    self.server = server;
 
     self.listen_new_toplevel_decoration.notify = handleNewToplevelDecoration;
     c.wl_signal_add(
@@ -50,5 +54,5 @@ fn handleNewToplevelDecoration(listener: ?*c.wl_listener, data: ?*c_void) callco
         c.wl_resource_post_no_memory(wlr_xdg_toplevel_decoration.resource);
         return;
     };
-    decoration.init(wlr_xdg_toplevel_decoration);
+    decoration.init(self.server, wlr_xdg_toplevel_decoration);
 }

--- a/river/View.zig
+++ b/river/View.zig
@@ -89,6 +89,8 @@ saved_buffers: std.ArrayList(SavedBuffer),
 /// view returns to floating mode.
 float_box: Box,
 
+draw_borders: bool,
+
 pub fn init(self: *Self, output: *Output, tags: u32, surface: var) void {
     self.output = output;
 
@@ -112,6 +114,8 @@ pub fn init(self: *Self, output: *Output, tags: u32, surface: var) void {
     self.pending_serial = null;
 
     self.saved_buffers = std.ArrayList(SavedBuffer).init(util.gpa);
+
+    self.draw_borders = true;
 
     if (@TypeOf(surface) == *c.wlr_xdg_surface) {
         self.impl = .{ .xdg_toplevel = undefined };

--- a/river/render.zig
+++ b/river/render.zig
@@ -88,7 +88,7 @@ pub fn renderOutput(output: *Output) void {
             if (view.focused) continue;
 
             renderView(output.*, view, &now);
-            renderBorders(output.*, view, &now);
+            if (view.draw_borders) renderBorders(output.*, view, &now);
         }
 
         // Render focused views
@@ -104,7 +104,7 @@ pub fn renderOutput(output: *Output) void {
             if (!view.focused) continue;
 
             renderView(output.*, view, &now);
-            renderBorders(output.*, view, &now);
+            if (view.draw_borders) renderBorders(output.*, view, &now);
         }
 
         if (build_options.xwayland) renderXwaylandUnmanaged(output.*, &now);


### PR DESCRIPTION
As discussed in IRC an hour ago.

This adds a list of app_ids which are  allowed to use client side decorations. These views will not be set to tiled (beware: the views will still be tiled by river and her layouts, this is just a status influencing how applications draw their windows), they are instructed to use client side decorations and they will not get a border drawn by river.

![Swappshot Thu Jul 16 01:19:40 2020](https://user-images.githubusercontent.com/49593314/87609702-8cd7be80-c703-11ea-8b60-dfdb0e6f4d61.png)

This settles the CSD vs SSD debate by simply doing both, allowing applications of both kinds to look as intended. Beware that the default is still SSD though.



Currently there is no way of adding any app_ids to the list. I will create a follow-up PR implementing a commands for pushing app_ids to the csd_filter list and the float_filter list.

For testing purposes, the app_id "csd" is hardcoded into the list for now (will be removed with the above PR). You can test this for example with `alacritty --class csd` (alacritty has client side decorations).