### PR TITLE
view: double buffer focus, use counter not bool

### DIFF
--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -555,7 +555,7 @@ fn viewSurfaceAt(output: Output, ox: f64, oy: f64, sx: *f64, sy: *f64) ?*c.wlr_s
     // Focused views are rendered on top, so look for them first.
     var it = ViewStack(View).iterator(output.views.first, output.current.tags);
     while (it.next()) |node| {
-        if (!node.view.focused) continue;
+        if (node.view.current.focus == 0) continue;
         if (node.view.surfaceAt(ox, oy, sx, sy)) |found| return found;
     }
 

--- a/river/Root.zig
+++ b/river/Root.zig
@@ -141,7 +141,7 @@ fn startTransaction(self: *Self) void {
 
             if (view.needsConfigure()) {
                 view.configure();
-                self.pending_configures += 1;
+                if (!view.pending.float) self.pending_configures += 1;
 
                 // Send a frame done that the client will commit a new frame
                 // with the dimensions we sent in the configure. Normally this

--- a/river/VoidView.zig
+++ b/river/VoidView.zig
@@ -28,11 +28,7 @@ pub fn needsConfigure(self: Self) bool {
     unreachable;
 }
 
-pub fn configure(self: Self, pending_box: Box) void {
-    unreachable;
-}
-
-pub fn setActivated(self: Self, activated: bool) void {
+pub fn configure(self: Self) void {
     unreachable;
 }
 

--- a/river/XwaylandView.zig
+++ b/river/XwaylandView.zig
@@ -63,14 +63,15 @@ pub fn needsConfigure(self: Self) bool {
         self.wlr_xwayland_surface.height != self.view.pending.box.height;
 }
 
-/// Tell the client to take a new size
-pub fn configure(self: Self, pending_box: Box) void {
+/// Apply pending state
+pub fn configure(self: Self) void {
+    const state = &self.view.pending;
     c.wlr_xwayland_surface_configure(
         self.wlr_xwayland_surface,
-        @intCast(i16, pending_box.x),
-        @intCast(i16, pending_box.y),
-        @intCast(u16, pending_box.width),
-        @intCast(u16, pending_box.height),
+        @intCast(i16, state.box.x),
+        @intCast(i16, state.box.y),
+        @intCast(u16, state.box.width),
+        @intCast(u16, state.box.height),
     );
     // Xwayland surfaces don't use serials, so we will just assume they have
     // configured the next time they commit. Set pending serial to a dummy
@@ -78,11 +79,6 @@ pub fn configure(self: Self, pending_box: Box) void {
     // call notifyConfigured() here as the transaction has not yet been fully
     // initiated.
     self.view.pending_serial = 0x66666666;
-}
-
-/// Inform the xwayland surface that it has gained focus
-pub fn setActivated(self: Self, activated: bool) void {
-    c.wlr_xwayland_surface_activate(self.wlr_xwayland_surface, activated);
 }
 
 pub fn setFullscreen(self: Self, fullscreen: bool) void {

--- a/river/render.zig
+++ b/river/render.zig
@@ -85,7 +85,7 @@ pub fn renderOutput(output: *Output) void {
             if (view.current.box.width == 0 or view.current.box.height == 0) continue;
 
             // Focused views are rendered on top of normal views, skip them for now
-            if (view.focused) continue;
+            if (view.current.focus != 0) continue;
 
             renderView(output.*, view, &now);
             if (view.draw_borders) renderBorders(output.*, view, &now);
@@ -101,7 +101,7 @@ pub fn renderOutput(output: *Output) void {
             if (view.current.box.width == 0 or view.current.box.height == 0) continue;
 
             // Skip unfocused views since we already rendered them
-            if (!view.focused) continue;
+            if (view.current.focus == 0) continue;
 
             renderView(output.*, view, &now);
             if (view.draw_borders) renderBorders(output.*, view, &now);
@@ -254,7 +254,7 @@ fn renderTexture(
 
 fn renderBorders(output: Output, view: *View, now: *c.timespec) void {
     const config = &output.root.server.config;
-    const color = if (view.focused) &config.border_color_focused else &config.border_color_unfocused;
+    const color = if (view.current.focus != 0) &config.border_color_focused else &config.border_color_unfocused;
     const border_width = config.border_width;
     const actual_box = if (view.saved_buffers.items.len != 0) view.saved_surface_box else view.surface_box;
 


### PR DESCRIPTION
- Double buffering focus state ensures that border color is kept in sync
with the transaction state of views in the layout.
- Using a counter instead of a bool will allow for proper handling of
multiple seats. This is done in the same commit to avoid more churn in
the future.