### PR TITLE
Fix bug causing river to crash when layouts define a too small view size

### DIFF
--- a/river/Output.zig
+++ b/river/Output.zig
@@ -269,8 +269,10 @@ fn layoutExternal(self: *Self, visible_count: u32) !void {
         var box = try parseBox(token);
         box.x += self.usable_box.x + xy_offset;
         box.y += self.usable_box.y + xy_offset;
-        box.width -= delta_size;
-        box.height -= delta_size;
+
+        if (box.width > delta_size) box.width -= delta_size;
+        if (box.height > delta_size) box.height -= delta_size;
+
         try view_boxen.append(box);
     }
 


### PR DESCRIPTION
~~Currently, river allows resizing views to 0x0, with mouse and via layout. To small sizes may cause severe issues in some applications and a size of 0x0 is a protocol error. Some views, such as GTK ones, set constraints, however this is only an optional feature of the XDG-Shell. To prevent too small views, this PR enforces a minimal view size of 50x50 for both layouts and mouse resizing. This is a totally arbitrary number, low enough to not get in the way of the user but high enough to not cause issues in applications.~~

~~Additionally,~~ this PR fixes a crashing bug which is encountered when a layout defines a width or height smaller than `delta_size`.