### PR TITLE
root: refactor transaction initiation

### DIFF
--- a/river/InputManager.zig
+++ b/river/InputManager.zig
@@ -149,6 +149,8 @@ fn handleInhibitDeactivate(listener: ?*c.wl_listener, data: ?*c_void) callconv(.
     while (seat_it) |seat_node| : (seat_it = seat_node.next) {
         seat_node.data.focus(null);
     }
+
+    self.server.root.startTransaction();
 }
 
 /// This event is raised by the backend when a new input device becomes available.

--- a/river/LayerSurface.zig
+++ b/river/LayerSurface.zig
@@ -154,6 +154,8 @@ fn handleUnmap(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) void {
         const seat = &node.data;
         seat.focus(null);
     }
+
+    self.output.root.startTransaction();
 }
 
 fn handleCommit(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) void {
@@ -181,6 +183,7 @@ fn handleCommit(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) void {
     // TODO: only reconfigure if things haven't changed
     // https://github.com/swaywm/wlroots/issues/1079
     self.output.arrangeLayers();
+    self.output.root.startTransaction();
 }
 
 fn handleNewPopup(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) void {

--- a/river/Output.zig
+++ b/river/Output.zig
@@ -304,7 +304,7 @@ pub fn arrangeViews(self: *Self) void {
     var it = ViewStack(View).pendingIterator(self.views.first, self.pending.tags);
     while (it.next()) |node| {
         const view = &node.view;
-        if (!view.pending.float) layout_count += 1;
+        if (!view.pending.float and !view.pending.fullscreen) layout_count += 1;
     }
 
     // If the usable area has a zero dimension, trying to arrange the layout
@@ -394,8 +394,6 @@ pub fn arrangeLayers(self: *Self) void {
             }
         }
     }
-
-    self.root.startTransaction();
 }
 
 /// Arrange the layer surfaces of a given layer
@@ -585,7 +583,7 @@ fn handleDestroy(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) void {
     while (seat_it) |seat_node| : (seat_it = seat_node.next) {
         const seat = &seat_node.data;
         if (seat.focused_output == self) {
-            seat.focusOutput(self);
+            seat.focusOutput(fallback_output);
             seat.focus(null);
         }
     }

--- a/river/Root.zig
+++ b/river/Root.zig
@@ -241,8 +241,4 @@ fn commitTransaction(self: *Self) void {
 
         if (view_tags_changed) output.sendViewTags();
     }
-
-    // Iterate over all seats and update focus
-    var it = self.server.input_manager.seats.first;
-    while (it) |seat_node| : (it = seat_node.next) seat_node.data.focus(null);
 }

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -120,21 +120,21 @@ pub fn focus(self: *Self, _view: ?*View) void {
     // If the view is not currently visible, behave as if null was passed
     if (view) |v| {
         if (v.output != self.focused_output or
-            v.current.tags & self.focused_output.current.tags == 0) view = null;
+            v.pending.tags & self.focused_output.pending.tags == 0) view = null;
     }
 
     // If the target view is not fullscreen or null, then a fullscreen view
     // will grab focus if visible.
-    if (if (view) |v| !v.current.fullscreen else true) {
-        var it = ViewStack(*View).iterator(self.focus_stack.first, self.focused_output.current.tags);
+    if (if (view) |v| !v.pending.fullscreen else true) {
+        var it = ViewStack(*View).pendingIterator(self.focus_stack.first, self.focused_output.pending.tags);
         view = while (it.next()) |node| {
-            if (node.view.output == self.focused_output and node.view.current.fullscreen) break node.view;
+            if (node.view.output == self.focused_output and node.view.pending.fullscreen) break node.view;
         } else view;
     }
 
     if (view == null) {
         // Set view to the first currently visible view in the focus stack if any
-        var it = ViewStack(*View).iterator(self.focus_stack.first, self.focused_output.current.tags);
+        var it = ViewStack(*View).pendingIterator(self.focus_stack.first, self.focused_output.pending.tags);
         view = while (it.next()) |node| {
             if (node.view.output == self.focused_output) break node.view;
         } else null;
@@ -223,9 +223,6 @@ pub fn setFocusRaw(self: *Self, new_focus: FocusTarget) void {
     // Inform any clients tracking status of the change
     var it = self.status_trackers.first;
     while (it) |node| : (it = node.next) node.data.sendFocusedView();
-
-    // Start a transaction to apply the pending focus state
-    self.input_manager.server.root.startTransaction();
 }
 
 /// Focus the given output, notifying any listening clients of the change.

--- a/river/View.zig
+++ b/river/View.zig
@@ -351,7 +351,8 @@ pub fn map(self: *Self) void {
 
     self.output.sendViewTags();
 
-    self.output.arrangeViews();
+    if (!self.current.float) self.output.arrangeViews();
+
     self.output.root.startTransaction();
 }
 
@@ -377,10 +378,9 @@ pub fn unmap(self: *Self) void {
     self.output.sendViewTags();
 
     // Still need to arrange if fullscreened from the layout
-    if (!self.current.float) {
-        self.output.arrangeViews();
-        root.startTransaction();
-    }
+    if (!self.current.float) self.output.arrangeViews();
+
+    root.startTransaction();
 }
 
 /// Destory the view and free the ViewStack node holding it.

--- a/river/View.zig
+++ b/river/View.zig
@@ -167,16 +167,10 @@ pub fn applyPending(self: *Self) void {
         self.pending.box = self.float_box;
 
     // If switching to fullscreen set the dimensions to the full area of the output
-    if (!self.current.fullscreen and self.pending.fullscreen) {
+    if (!self.current.fullscreen and self.pending.fullscreen)
         self.pending.box = Box.fromWlrBox(
             c.wlr_output_layout_get_box(self.output.root.wlr_output_layout, self.output.wlr_output).*,
         );
-        // TODO: move this to configure
-        switch (self.impl) {
-            .xdg_toplevel => |xdg_toplevel| xdg_toplevel.setFullscreen(self.pending.fullscreen),
-            .xwayland_view => |xwayland_view| xwayland_view.setFullscreen(self.pending.fullscreen),
-        }
-    }
 
     // If switching from fullscreen to layout, arrange the output to get
     // assigned the proper size.

--- a/river/VoidView.zig
+++ b/river/VoidView.zig
@@ -32,10 +32,6 @@ pub fn configure(self: Self) void {
     unreachable;
 }
 
-pub fn setFullscreen(self: Self, fullscreen: bool) void {
-    unreachable;
-}
-
 pub fn close(self: Self) void {
     unreachable;
 }

--- a/river/XdgToplevel.zig
+++ b/river/XdgToplevel.zig
@@ -82,15 +82,12 @@ pub fn needsConfigure(self: Self) bool {
 pub fn configure(self: Self) void {
     const state = &self.view.pending;
     _ = c.wlr_xdg_toplevel_set_activated(self.wlr_xdg_surface, state.focus != 0);
+    _ = c.wlr_xdg_toplevel_set_fullscreen(self.wlr_xdg_surface, state.fullscreen);
     self.view.pending_serial = c.wlr_xdg_toplevel_set_size(
         self.wlr_xdg_surface,
         state.box.width,
         state.box.height,
     );
-}
-
-pub fn setFullscreen(self: Self, fullscreen: bool) void {
-    _ = c.wlr_xdg_toplevel_set_fullscreen(self.wlr_xdg_surface, fullscreen);
 }
 
 /// Close the view. This will lead to the unmap and destroy events being sent

--- a/river/XwaylandView.zig
+++ b/river/XwaylandView.zig
@@ -66,6 +66,7 @@ pub fn needsConfigure(self: Self) bool {
 /// Apply pending state
 pub fn configure(self: Self) void {
     const state = &self.view.pending;
+    c.wlr_xwayland_surface_set_fullscreen(self.wlr_xwayland_surface, state.fullscreen);
     c.wlr_xwayland_surface_configure(
         self.wlr_xwayland_surface,
         @intCast(i16, state.box.x),
@@ -79,10 +80,6 @@ pub fn configure(self: Self) void {
     // call notifyConfigured() here as the transaction has not yet been fully
     // initiated.
     self.view.pending_serial = 0x66666666;
-}
-
-pub fn setFullscreen(self: Self, fullscreen: bool) void {
-    c.wlr_xwayland_surface_set_fullscreen(self.wlr_xwayland_surface, fullscreen);
 }
 
 /// Close the view. This will lead to the unmap and destroy events being sent

--- a/river/command/config.zig
+++ b/river/command/config.zig
@@ -31,7 +31,8 @@ pub fn borderWidth(
 
     const server = seat.input_manager.server;
     server.config.border_width = try std.fmt.parseInt(u32, args[1], 10);
-    server.root.arrange();
+    server.root.arrangeAll();
+    server.root.startTransaction();
 }
 
 pub fn viewPadding(
@@ -45,7 +46,8 @@ pub fn viewPadding(
 
     const server = seat.input_manager.server;
     server.config.view_padding = try std.fmt.parseInt(u32, args[1], 10);
-    server.root.arrange();
+    server.root.arrangeAll();
+    server.root.startTransaction();
 }
 
 pub fn outerPadding(
@@ -59,7 +61,8 @@ pub fn outerPadding(
 
     const server = seat.input_manager.server;
     server.config.outer_padding = try std.fmt.parseInt(u32, args[1], 10);
-    server.root.arrange();
+    server.root.arrangeAll();
+    server.root.startTransaction();
 }
 
 pub fn backgroundColor(

--- a/river/command/focus_view.zig
+++ b/river/command/focus_view.zig
@@ -53,6 +53,7 @@ pub fn focusView(
         // Focus the next visible node if there is one
         if (it.next()) |node| {
             seat.focus(&node.view);
+            output.root.startTransaction();
             return;
         }
     }
@@ -65,4 +66,5 @@ pub fn focusView(
     };
 
     seat.focus(if (it.next()) |node| &node.view else null);
+    output.root.startTransaction();
 }

--- a/river/command/mod_master_count.zig
+++ b/river/command/mod_master_count.zig
@@ -33,5 +33,6 @@ pub fn modMasterCount(
     const delta = try std.fmt.parseInt(i32, args[1], 10);
     const output = seat.focused_output;
     output.master_count = @intCast(u32, std.math.max(0, @intCast(i32, output.master_count) + delta));
-    seat.input_manager.server.root.arrange();
+    output.arrangeViews();
+    output.root.startTransaction();
 }

--- a/river/command/mod_master_factor.zig
+++ b/river/command/mod_master_factor.zig
@@ -35,6 +35,7 @@ pub fn modMasterFactor(
     const new_master_factor = std.math.min(std.math.max(output.master_factor + delta, 0.05), 0.95);
     if (new_master_factor != output.master_factor) {
         output.master_factor = new_master_factor;
-        seat.input_manager.server.root.arrange();
+        output.arrangeViews();
+        output.root.startTransaction();
     }
 }

--- a/river/command/send_to_output.zig
+++ b/river/command/send_to_output.zig
@@ -54,7 +54,9 @@ pub fn sendToOutput(
         seat.focused.view.sendToOutput(destination_output);
 
         // Handle the change and focus whatever's next in the focus stack
-        root.arrange();
         seat.focus(null);
+        seat.focused_output.arrangeViews();
+        destination_output.arrangeViews();
+        root.startTransaction();
     }
 }

--- a/river/command/tags.zig
+++ b/river/command/tags.zig
@@ -30,7 +30,8 @@ pub fn setFocusedTags(
     const tags = try parseTags(allocator, args, out);
     if (seat.focused_output.pending.tags != tags) {
         seat.focused_output.pending.tags = tags;
-        seat.input_manager.server.root.arrange();
+        seat.focused_output.arrangeViews();
+        seat.focused_output.root.startTransaction();
     }
 }
 
@@ -44,7 +45,7 @@ pub fn setViewTags(
     const tags = try parseTags(allocator, args, out);
     if (seat.focused == .view) {
         seat.focused.view.pending.tags = tags;
-        seat.focused.view.output.root.arrange();
+        seat.focused.view.applyPending();
     }
 }
 
@@ -60,7 +61,8 @@ pub fn toggleFocusedTags(
     const new_focused_tags = output.pending.tags ^ tags;
     if (new_focused_tags != 0) {
         output.pending.tags = new_focused_tags;
-        seat.input_manager.server.root.arrange();
+        output.arrangeViews();
+        output.root.startTransaction();
     }
 }
 
@@ -76,7 +78,7 @@ pub fn toggleViewTags(
         const new_tags = seat.focused.view.current.tags ^ tags;
         if (new_tags != 0) {
             seat.focused.view.pending.tags = new_tags;
-            seat.focused.view.output.root.arrange();
+            seat.focused.view.applyPending();
         }
     }
 }

--- a/river/command/tags.zig
+++ b/river/command/tags.zig
@@ -31,6 +31,7 @@ pub fn setFocusedTags(
     if (seat.focused_output.pending.tags != tags) {
         seat.focused_output.pending.tags = tags;
         seat.focused_output.arrangeViews();
+        seat.focus(null);
         seat.focused_output.root.startTransaction();
     }
 }
@@ -44,8 +45,10 @@ pub fn setViewTags(
 ) Error!void {
     const tags = try parseTags(allocator, args, out);
     if (seat.focused == .view) {
-        seat.focused.view.pending.tags = tags;
-        seat.focused.view.applyPending();
+        const view = seat.focused.view;
+        view.pending.tags = tags;
+        seat.focus(null);
+        view.applyPending();
     }
 }
 
@@ -62,6 +65,7 @@ pub fn toggleFocusedTags(
     if (new_focused_tags != 0) {
         output.pending.tags = new_focused_tags;
         output.arrangeViews();
+        seat.focus(null);
         output.root.startTransaction();
     }
 }
@@ -75,10 +79,12 @@ pub fn toggleViewTags(
 ) Error!void {
     const tags = try parseTags(allocator, args, out);
     if (seat.focused == .view) {
-        const new_tags = seat.focused.view.current.tags ^ tags;
+        const new_tags = seat.focused.view.pending.tags ^ tags;
         if (new_tags != 0) {
-            seat.focused.view.pending.tags = new_tags;
-            seat.focused.view.applyPending();
+            const view = seat.focused.view;
+            view.pending.tags = new_tags;
+            seat.focus(null);
+            view.applyPending();
         }
     }
 }

--- a/river/command/toggle_float.zig
+++ b/river/command/toggle_float.zig
@@ -40,18 +40,6 @@ pub fn toggleFloat(
         if (seat.input_manager.isCursorActionTarget(view)) return;
 
         view.pending.float = !view.pending.float;
-
-        if (view.pending.float) {
-            // If switching from layout to float, restore the previous floating
-            // dimensions.
-            view.pending.box = view.float_box;
-            view.configure();
-        } else {
-            // If switching from float to layout save the floating dimensions
-            // for next time.
-            view.float_box = view.current.box;
-        }
-
-        view.output.root.arrange();
+        view.applyPending();
     }
 }

--- a/river/command/toggle_fullscreen.zig
+++ b/river/command/toggle_fullscreen.zig
@@ -38,6 +38,7 @@ pub fn toggleFullscreen(
         // Don't modify views which are the target of a cursor action
         if (seat.input_manager.isCursorActionTarget(view)) return;
 
-        view.setFullscreen(!view.pending.fullscreen);
+        view.pending.fullscreen = !view.pending.fullscreen;
+        view.applyPending();
     }
 }

--- a/river/command/zoom.zig
+++ b/river/command/zoom.zig
@@ -56,8 +56,9 @@ pub fn zoom(
         if (zoom_node) |to_bump| {
             output.views.remove(to_bump);
             output.views.push(to_bump);
-            seat.input_manager.server.root.arrange();
             seat.focus(&to_bump.view);
+            output.arrangeViews();
+            output.root.startTransaction();
         }
     }
 }


### PR DESCRIPTION
- require the caller to use Root.startTransaction() directly
- introduce View.applyPending() to unify logic
- introduce View.shouldTrackConfigure() to unify more logic
- update all callsites to intelligently rearrange only what is necessary