### PR TITLE
view: implement frame-perfect destroy

### DIFF
--- a/river/Output.zig
+++ b/river/Output.zig
@@ -288,7 +288,7 @@ fn layoutExternal(self: *Self, visible_count: u32) !void {
     var view_it = ViewStack(View).pendingIterator(self.views.first, self.pending.tags);
     while (view_it.next()) |node| {
         const view = &node.view;
-        if (!view.pending.float and !view.pending.fullscreen) {
+        if (!view.pending.float and !view.pending.fullscreen and !view.destroying) {
             view.pending.box = view_boxen.items[i];
             view.applyConstraints();
             i += 1;
@@ -309,7 +309,7 @@ pub fn arrangeViews(self: *Self) void {
     var it = ViewStack(View).pendingIterator(self.views.first, self.pending.tags);
     while (it.next()) |node| {
         const view = &node.view;
-        if (!view.pending.float and !view.pending.fullscreen) layout_count += 1;
+        if (!view.pending.float and !view.pending.fullscreen and !view.destroying) layout_count += 1;
     }
 
     // If the usable area has a zero dimension, trying to arrange the layout

--- a/river/VoidView.zig
+++ b/river/VoidView.zig
@@ -24,6 +24,10 @@ const c = @import("c.zig");
 const Box = @import("Box.zig");
 const View = @import("View.zig");
 
+pub fn deinit(self: *Self) void {
+    unreachable;
+}
+
 pub fn needsConfigure(self: Self) bool {
     unreachable;
 }


### PR DESCRIPTION
river's View objects may now outlive their wlroots counterparts so that
we can continue to render a destroyed view until the transaction is
completed.

Closes #79

This could use some more testing. I can't reproduce the frame imperfection on closing views anymore but I can forsee some edge cases where this could cause a crash.