### PR TITLE
Focus follows cursor

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -116,6 +116,13 @@ that tag 1 through 9 are visible.
 *enter-mode* _name_
 	Switch to given mode if it exits.
 
+*focus-follows-cursor* _disabled_|_normal_|_strict_
+	When _disabled_ moving the cursor will not influence the focus. This is the default setting.
+	If set to _normal_ moving the cursor over a window will focus that window.
+	The focus still can be changed and moving the cursor within the (now unfocused) window will not change the focus to that window
+	but let the currently focused window in focus.
+	When set to _strict_ this is not the case. The focus will be updated on every cursor movement.
+
 *map* _mode_ _modifiers_ _key_ _command_
 	_mode_ is either “normal” (the default mode) or a mode created with
 	*declare-mode*. _modifiers_ is a list of one or more of the following

--- a/river/Config.zig
+++ b/river/Config.zig
@@ -25,6 +25,14 @@ const util = @import("util.zig");
 const Server = @import("Server.zig");
 const Mode = @import("Mode.zig");
 
+pub const FocusFollowsCursorMode = enum {
+    disabled,
+    /// Only change focus on entering a surface
+    normal,
+    /// On cursor movement the focus will be updated to the surface below the cursor
+    strict,
+};
+
 /// Color of background in RGBA (alpha should only affect nested sessions)
 background_color: [4]f32 = [_]f32{ 0.0, 0.16862745, 0.21176471, 1.0 }, // Solarized base03
 
@@ -54,6 +62,9 @@ float_filter: std.ArrayList([]const u8),
 
 /// List of app_ids which are allowed to use client side decorations
 csd_filter: std.ArrayList([]const u8),
+
+/// The selected focus_follows_cursor mode
+focus_follows_cursor: FocusFollowsCursorMode = .disabled,
 
 pub fn init() !Self {
     var self = Self{

--- a/river/command.zig
+++ b/river/command.zig
@@ -42,6 +42,7 @@ const str_to_impl_fn = [_]struct {
     .{ .name = "exit",                   .impl = @import("command/exit.zig").exit },
     .{ .name = "float-filter-add",       .impl = @import("command/filter.zig").floatFilterAdd },
     .{ .name = "focus-output",           .impl = @import("command/focus_output.zig").focusOutput },
+    .{ .name = "focus-follows-cursor",   .impl = @import("command/focus_follows_cursor.zig").focusFollowsCursor },
     .{ .name = "focus-view",             .impl = @import("command/focus_view.zig").focusView },
     .{ .name = "layout",                 .impl = @import("command/layout.zig").layout },
     .{ .name = "map",                    .impl = @import("command/map.zig").map },

--- a/river/command/focus_follows_cursor.zig
+++ b/river/command/focus_follows_cursor.zig
@@ -1,0 +1,39 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2020 Marten Ringwelski
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+
+const util = @import("../util.zig");
+
+const Config = @import("../Config.zig");
+const Error = @import("../command.zig").Error;
+const Seat = @import("../Seat.zig");
+
+pub fn focusFollowsCursor(
+    allocator: *std.mem.Allocator,
+    seat: *Seat,
+    args: []const []const u8,
+    out: *?[]const u8,
+) Error!void {
+    if (args.len < 2) return Error.NotEnoughArguments;
+    if (args.len > 2) return Error.TooManyArguments;
+
+    const server = seat.input_manager.server;
+
+    server.config.focus_follows_cursor =
+        std.meta.stringToEnum(Config.FocusFollowsCursorMode, args[1]) orelse return Error.UnknownOption;
+}


### PR DESCRIPTION
This PR implements the `focus-follows-cursor` command as described in the man page.

In https://github.com/ifreund/river/commit/e05b22ba443e86dd3255e98f559f62c8b4b94f6c the `surfaceAt`, `layerSurfaceAt` etc. functions are moved to output because it seemed more reasonable to have them there.

~I think it works. I've also tested with layer surfaces. The behavior seems strange but I think it is desired. Analogous to this line you cant change the focus with keybindings when the cursor is over a layer surface.~
https://github.com/ifreund/river/blob/976a3ce73d3f83c94576e1220bebbaf79cc8c0e5/river/Seat.zig#L101-L102

~The last thing remaining is that the border is not updated when the focus is changed. I need help with this one.
Looking at https://github.com/ifreund/river/blob/master/river/command/focus_view.zig it seems that `root.startTransaction()` is needed after the focus change but this crashes with an integer overflow.~
```
integer overflow
/home/marten/workspace/Fork/river/river/Root.zig:195:29: 0x2773c6 in Root.notifyConfigured (river)
    self.pending_configures -= 1;
```

Closes #78 