### PR TITLE
Implement map -release

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -123,9 +123,11 @@ that tag 1 through 9 are visible.
 	but let the currently focused window in focus.
 	When set to _strict_ this is not the case. The focus will be updated on every cursor movement.
 
-*map* _mode_ _modifiers_ _key_ _command_
+*map* [-release] _mode_ _modifiers_ _key_ _command_
 	_mode_ is either “normal” (the default mode) or a mode created with
-	*declare-mode*. _modifiers_ is a list of one or more of the following
+	*declare-mode*.
+	If _-release_ is specified the mapping is executed on key release rather than key press.
+	_modifiers_ is a list of one or more of the following
 	modifiers separated with a plus sign:
 
 	- Shift

--- a/river/Mapping.zig
+++ b/river/Mapping.zig
@@ -25,10 +25,14 @@ keysym: c.xkb_keysym_t,
 modifiers: u32,
 command_args: []const []const u8,
 
+/// When set to true the mapping will be executed on key release rather than on press
+release: bool,
+
 pub fn init(
     allocator: *std.mem.Allocator,
     keysym: c.xkb_keysym_t,
     modifiers: u32,
+    release: bool,
     command_args: []const []const u8,
 ) !Self {
     const owned_args = try allocator.alloc([]u8, command_args.len);
@@ -40,6 +44,7 @@ pub fn init(
     return Self{
         .keysym = keysym,
         .modifiers = modifiers,
+        .release = release,
         .command_args = owned_args,
     };
 }

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -262,10 +262,10 @@ pub fn handleViewUnmap(self: *Self, view: *View) void {
 
 /// Handle any user-defined mapping for the passed keysym and modifiers
 /// Returns true if the key was handled
-pub fn handleMapping(self: *Self, keysym: c.xkb_keysym_t, modifiers: u32) bool {
+pub fn handleMapping(self: *Self, keysym: c.xkb_keysym_t, modifiers: u32, released: bool) bool {
     const modes = &self.input_manager.server.config.modes;
     for (modes.items[self.mode_id].mappings.items) |mapping| {
-        if (modifiers == mapping.modifiers and keysym == mapping.keysym) {
+        if (modifiers == mapping.modifiers and keysym == mapping.keysym and released == mapping.release) {
             // Execute the bound command
             const args = mapping.command_args;
             var out: ?[]const u8 = null;


### PR DESCRIPTION
This implements `-release` from #98.
It also paves the way to implement more optional arguments for map which I plan doing.
~One controversial thing might be moving up the allocation of `Mapping` in `map.zig`. I think it is acceptable because it will only occur when a duplicate mapping would be assigned and this should not happen often. The benefit is the `isEqual` function in `Mapping` which IMO improves readablity.~

To test you can use:
```
riverctl map normal Mod4 F toggle-fullscreen
riverctl map -release normal Mod4 F toggle-fullscreen
```