### PR TITLE
Optional args parsing

### DIFF
--- a/river/test_main.zig
+++ b/river/test_main.zig
@@ -17,4 +17,5 @@
 
 test "river test suite" {
     _ = @import("view_stack.zig");
+    _ = @import("command.zig");
 }


### PR DESCRIPTION
I've implemented your suggestion from https://github.com/ifreund/river/issues/102#issuecomment-693645836.

There are several things left to be discussed and solved.
I've implemented options with an Int argument too to figure out a good way to parse the argument.
When merging this I will of course use this for `map -release` and remove the Int option as it is not needed.

### Default Options for bools
Since boolean options are either given or not given I'd like to make the default be false always and change them to true when the argument is given. 
A possibility would be to make it a compile error to have the default value set to false. This is what I implemented currently as it seems clean and explicit about the default beeing false.
Another idea would be to make giving the option toggle the default value. Code wise this would be the simplest but I really dislike this one as there is really no use for that imo.

### Enforce naming of arguments
Since we decided to always have arguments be in the form `-long-option` we could implement a check to enforce correct naming at compile time. Is there anything bad about this?

### Setting the offset
The last thing I'm not happy with is setting the offset. The offset is needed for the caller to know where to continue parsing.
If there was a way to run an else branch after a for loop even when the for loop breaks it would be nice to set it there.
There was a issue in the zig bugtracker somewhere but I can't seem to find it.

Closes #102