### PR TITLE
#107, but with timers and double buffering

### DIFF
--- a/contrib/config.sh
+++ b/contrib/config.sh
@@ -100,3 +100,5 @@ riverctl float-filter-add "popup"
 # Set app-ids of views which should use client side decorations
 riverctl csd-filter-add "gedit"
 
+# Set opacity and fade effect
+# riverctl opacity 1.0 0.75 0.0 0.1 20

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -162,6 +162,21 @@ that tag 1 through 9 are visible.
 	- move-view
 	- resize-view
 
+*opacity* _focused-opacity_ _unfocused-opacity_ _starting-opacity_ _opacity-step_ _opacity-delta-t_
+	Set the server side opacity of views.
+
+	_focused-opacity_ sets the opacity of the focused window, _unfocused-opacity_
+	the opacity of every unfocused window while _starting-opacity_ sets the
+	opacity a window will have at startup before immediately transitioning to
+	either the focused or unfocused opacity. These settings require a floating
+	point number from 0.0 (fully transparent) to 1.0 (fully opaque).
+
+	Opacity transitions can be animated. _opacity-step_ sets the amount the
+	opacity should be increased or decreased per step of the transition. It
+	requires a floating point number from 0.05 to 1.0. If set to 1.0, animations
+	are disabled. _opacity-delta-t_ sets the time between the transition steps
+	in milliseconds.
+
 *outer-padding* _pixels_
 	Set the padding around the edge of the screen to _pixels_.
 

--- a/river/Config.zig
+++ b/river/Config.zig
@@ -66,6 +66,21 @@ csd_filter: std.ArrayList([]const u8),
 /// The selected focus_follows_cursor mode
 focus_follows_cursor: FocusFollowsCursorMode = .disabled,
 
+/// The opacity of the focused view
+view_opacity_focused: f32 = 1.0,
+
+/// The opacity of unfocused views
+view_opacity_unfocused: f32 = 1.0,
+
+/// The starting opacity of new views
+view_opacity_initial: f32 = 1.0,
+
+/// View opacity transition step
+view_opacity_delta: f32 = 1.0,
+
+/// Time between view opacity transition steps in msec
+view_opacity_delta_t: u31 = 20,
+
 pub fn init() !Self {
     var self = Self{
         .mode_to_id = std.StringHashMap(usize).init(util.gpa),

--- a/river/Root.zig
+++ b/river/Root.zig
@@ -250,6 +250,8 @@ fn commitTransaction(self: *Self) void {
             view.current = view.pending;
 
             view.dropSavedBuffers();
+
+            view.commitOpacityTransition();
         }
 
         if (view_tags_changed) output.sendViewTags();

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -188,6 +188,9 @@ pub fn setFocusRaw(self: *Self, new_focus: FocusTarget) void {
             // activated state.
             if (build_options.xwayland and self.focused.view.impl == .xwayland_view)
                 c.wlr_xwayland_surface_activate(self.focused.view.impl.xwayland_view.wlr_xwayland_surface, false);
+            if (self.focused.view.pending.focus == 0) {
+                self.focused.view.pending.target_opacity = self.input_manager.server.config.view_opacity_unfocused;
+            }
         }
         c.wlr_seat_keyboard_clear_focus(self.wlr_seat);
 
@@ -200,6 +203,7 @@ pub fn setFocusRaw(self: *Self, new_focus: FocusTarget) void {
                 // activated state.
                 if (build_options.xwayland and target_view.impl == .xwayland_view)
                     c.wlr_xwayland_surface_activate(target_view.impl.xwayland_view.wlr_xwayland_surface, true);
+                target_view.pending.target_opacity = self.input_manager.server.config.view_opacity_focused;
             },
             .layer => |target_layer| std.debug.assert(self.focused_output == target_layer.output),
             .none => {},
@@ -281,7 +285,7 @@ pub fn handleMapping(self: *Self, keysym: c.xkb_keysym_t, modifiers: u32, releas
             if (out) |s| {
                 const stdout = std.io.getStdOut().outStream();
                 stdout.print("{}", .{s}) catch
-                    |err| log.err(.command, "{}: write to stdout failed {}", .{ args[0], err });
+                |err| log.err(.command, "{}: write to stdout failed {}", .{ args[0], err });
             }
             return true;
         }

--- a/river/XdgToplevel.zig
+++ b/river/XdgToplevel.zig
@@ -252,8 +252,10 @@ fn handleCommit(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) void {
             if (view.shouldTrackConfigure())
                 view.output.root.notifyConfigured()
             else {
+                const view_tags_changed = view.pending.tags != view.current.tags;
                 view.current = view.pending;
                 view.commitOpacityTransition();
+                if (view_tags_changed) view.output.sendViewTags();
             }
         } else {
             // If the client has not yet acked our configure, we need to send a

--- a/river/XdgToplevel.zig
+++ b/river/XdgToplevel.zig
@@ -251,8 +251,10 @@ fn handleCommit(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) void {
             view.pending_serial = null;
             if (view.shouldTrackConfigure())
                 view.output.root.notifyConfigured()
-            else
+            else {
                 view.current = view.pending;
+                view.commitOpacityTransition();
+            }
         } else {
             // If the client has not yet acked our configure, we need to send a
             // frame done event so that it commits another buffer. These

--- a/river/command.zig
+++ b/river/command.zig
@@ -49,6 +49,7 @@ const str_to_impl_fn = [_]struct {
     .{ .name = "map-pointer",            .impl = @import("command/map.zig").mapPointer },
     .{ .name = "mod-master-count",       .impl = @import("command/mod_master_count.zig").modMasterCount },
     .{ .name = "mod-master-factor",      .impl = @import("command/mod_master_factor.zig").modMasterFactor },
+    .{ .name = "opacity",                .impl = @import("command/opacity.zig").opacity },
     .{ .name = "outer-padding",          .impl = @import("command/config.zig").outerPadding },
     .{ .name = "send-to-output",         .impl = @import("command/send_to_output.zig").sendToOutput },
     .{ .name = "set-focused-tags",       .impl = @import("command/tags.zig").setFocusedTags },
@@ -73,6 +74,7 @@ pub const Error = error{
     InvalidCharacter,
     InvalidDirection,
     InvalidRgba,
+    InvalidValue,
     UnknownOption,
     OutOfMemory,
     Other,
@@ -113,6 +115,7 @@ pub fn errToMsg(err: Error) [:0]const u8 {
         Error.InvalidCharacter => "invalid character in argument",
         Error.InvalidDirection => "invalid direction. Must be 'next' or 'previous'",
         Error.InvalidRgba => "invalid color format, must be #RRGGBB or #RRGGBBAA",
+        Error.InvalidValue => "invalid value",
         Error.OutOfMemory => "out of memory",
         Error.Other => unreachable,
     };

--- a/river/command/opacity.zig
+++ b/river/command/opacity.zig
@@ -1,0 +1,79 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2020 Leon Henrik Plickat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+
+const Error = @import("../command.zig").Error;
+const Seat = @import("../Seat.zig");
+const View = @import("../View.zig");
+const ViewStack = @import("../view_stack.zig").ViewStack;
+
+fn opacityUpdateFilter(view: *View, context: void) bool {
+    // We want to update all views
+    return true;
+}
+
+pub fn opacity(
+    allocator: *std.mem.Allocator,
+    seat: *Seat,
+    args: []const []const u8,
+    out: *?[]const u8,
+) Error!void {
+    if (args.len < 6) return Error.NotEnoughArguments;
+    if (args.len > 6) return Error.TooManyArguments;
+
+    const server = seat.input_manager.server;
+
+    // Focused opacity
+    server.config.view_opacity_focused = try std.fmt.parseFloat(f32, args[1]);
+    if (server.config.view_opacity_focused < 0.0 or server.config.view_opacity_focused > 1.0)
+        return Error.InvalidValue;
+
+    // Unfocused opacity
+    server.config.view_opacity_unfocused = try std.fmt.parseFloat(f32, args[2]);
+    if (server.config.view_opacity_unfocused < 0.0 or server.config.view_opacity_unfocused > 1.0)
+        return Error.InvalidValue;
+
+    // Starting opacity for new views
+    server.config.view_opacity_initial = try std.fmt.parseFloat(f32, args[3]);
+    if (server.config.view_opacity_initial < 0.0 or server.config.view_opacity_initial > 1.0)
+        return Error.InvalidValue;
+
+    // Opacity transition step
+    server.config.view_opacity_delta = try std.fmt.parseFloat(f32, args[4]);
+    if (server.config.view_opacity_delta < 0.0 or server.config.view_opacity_delta > 1.0)
+        return Error.InvalidValue;
+
+    // Time between step
+    server.config.view_opacity_delta_t = try std.fmt.parseInt(u31, args[5], 10);
+    if (server.config.view_opacity_delta_t < 1) return Error.InvalidValue;
+
+    // Update opacity of all views
+    // Unmapped views will be skipped, however their opacity gets updated on map anyway
+    var oit = server.root.outputs.first;
+    while (oit) |onode| : (oit = onode.next) {
+        var vit = ViewStack(View).iter(onode.data.views.first, .forward, {}, opacityUpdateFilter);
+        while (vit.next()) |vnode| {
+            if (vnode.current.focus > 0) {
+                vnode.pending.target_opacity = server.config.view_opacity_focused;
+            } else {
+                vnode.pending.target_opacity = server.config.view_opacity_unfocused;
+            }
+        }
+    }
+    server.root.startTransaction();
+}


### PR DESCRIPTION
As the title states, this does what #107 does, but with timers. The way it is implemented also gives us a "fade in" effect on view map for free by setting the initial opacity to `0.0` (obviously configurable).

* [X] Implemented using per view opacity
* [X] (Optional) Fade effect between opacities
    * [X] Timers
    * [X] Avoids unnecessary transitions (example: no need to transition from 1.0 to 1.0)
    * [X] Animations can be disabled
    * [X] Each view has its own independent animation
    * [X] Supports changing target opacity mid-animation
    * [X] Animations are implemented in a clear and simple fashion with no magic
* [x] Opacity is double buffered
* [x] Everything is documented

I'll clean up the commits after the review.

---

For the animation I decided to use step-size instead of step-amount. This way the "speed" of the animation is constant instead of the time, which Feels Nicer™,  and is considerably easier to implement, especially w.r.t. changing the target opacity mid-animation. Also, looking at other project, this method of implementing fade effects appears to be more common.