### PR TITLE
Implement moving and resizing views via keyboard

### DIFF
--- a/contrib/config.sh
+++ b/contrib/config.sh
@@ -37,6 +37,24 @@ riverctl map normal $mod L mod-master-factor +0.05
 riverctl map normal $mod+Shift H mod-master-count +1
 riverctl map normal $mod+Shift L mod-master-count -1
 
+# Mod+Alt+{H,J,K,L} to move views
+riverctl map normal $mod+Mod1 H move left 100
+riverctl map normal $mod+Mod1 J move down 100
+riverctl map normal $mod+Mod1 K move up 100
+riverctl map normal $mod+Mod1 L move right 100
+
+# Mod+Alt+Control+{H,J,K,L} to snap views to screen edges
+riverctl map normal $mod+Mod1+Control H snap left
+riverctl map normal $mod+Mod1+Control J snap down
+riverctl map normal $mod+Mod1+Control K snap up
+riverctl map normal $mod+Mod1+Control L snap right
+
+# Mod+Alt+Shif+{H,J,K,L} to resize views
+riverctl map normal $mod+Mod1+Shift H resize horizontal -100
+riverctl map normal $mod+Mod1+Shift J resize vertical 100
+riverctl map normal $mod+Mod1+Shift K resize vertical -100
+riverctl map normal $mod+Mod1+Shift L resize horizontal 100
+
 # Mod + Left Mouse Button to move views
 riverctl map-pointer normal $mod BTN_LEFT move-view
 

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -53,6 +53,17 @@ used to control and configure river.
 	negative floating point number (such as 0.05) where 1 corresponds to
 	the whole screen.
 
+*move* *up*|*down*|*left*|*right* _delta_
+	Move the focused view in the specified direction by _delta_. The view will
+	be set to floating.
+
+*resize* *horizontal*|*vertical* _delta_
+	Resize the view in the given orientation by _delta_. The view will be set to
+	floating.
+
+*snap* *up*|*down*|*left*|*right*
+	Snap the view to the specified screen edge. The view will be set to floating.
+
 *send-to-output* *next*|*previous*
 	Send the focused view to the next or the previous output.
 

--- a/river/command.zig
+++ b/river/command.zig
@@ -24,6 +24,18 @@ pub const Direction = enum {
     previous,
 };
 
+pub const PhysicalDirection = enum {
+    up,
+    down,
+    left,
+    right,
+};
+
+pub const Orientation = enum {
+    horizontal,
+    vertical,
+};
+
 // TODO: this could be replaced with a comptime hashmap
 // zig fmt: off
 const str_to_impl_fn = [_]struct {
@@ -49,11 +61,14 @@ const str_to_impl_fn = [_]struct {
     .{ .name = "map-pointer",            .impl = @import("command/map.zig").mapPointer },
     .{ .name = "mod-master-count",       .impl = @import("command/mod_master_count.zig").modMasterCount },
     .{ .name = "mod-master-factor",      .impl = @import("command/mod_master_factor.zig").modMasterFactor },
+    .{ .name = "move",                   .impl = @import("command/move.zig").move },
     .{ .name = "opacity",                .impl = @import("command/opacity.zig").opacity },
     .{ .name = "outer-padding",          .impl = @import("command/config.zig").outerPadding },
+    .{ .name = "resize",                 .impl = @import("command/move.zig").resize },
     .{ .name = "send-to-output",         .impl = @import("command/send_to_output.zig").sendToOutput },
     .{ .name = "set-focused-tags",       .impl = @import("command/tags.zig").setFocusedTags },
     .{ .name = "set-view-tags",          .impl = @import("command/tags.zig").setViewTags },
+    .{ .name = "snap",                   .impl = @import("command/move.zig").snap },
     .{ .name = "spawn",                  .impl = @import("command/spawn.zig").spawn },
     .{ .name = "toggle-float",           .impl = @import("command/toggle_float.zig").toggleFloat },
     .{ .name = "toggle-focused-tags",    .impl = @import("command/tags.zig").toggleFocusedTags },
@@ -73,6 +88,8 @@ pub const Error = error{
     Overflow,
     InvalidCharacter,
     InvalidDirection,
+    InvalidPhysicalDirection,
+    InvalidOrientation,
     InvalidRgba,
     InvalidValue,
     UnknownOption,
@@ -114,6 +131,8 @@ pub fn errToMsg(err: Error) [:0]const u8 {
         Error.Overflow => "value out of bounds",
         Error.InvalidCharacter => "invalid character in argument",
         Error.InvalidDirection => "invalid direction. Must be 'next' or 'previous'",
+        Error.InvalidPhysicalDirection => "invalid direction. Must be 'up', 'down', 'left' or 'right'",
+        Error.InvalidOrientation => "invalid orientation. Must be 'horizontal', or 'vertical'",
         Error.InvalidRgba => "invalid color format, must be #RRGGBB or #RRGGBBAA",
         Error.InvalidValue => "invalid value",
         Error.OutOfMemory => "out of memory",

--- a/river/command/move.zig
+++ b/river/command/move.zig
@@ -62,10 +62,9 @@ pub fn snap(
     const direction = std.meta.stringToEnum(PhysicalDirection, args[1]) orelse
         return Error.InvalidPhysicalDirection;
 
-    const view = get_view(seat) orelse return;
-    const output_box = get_output_dimensions(view);
     const view = getView(seat) orelse return;
     const border_width = @intCast(i32, view.output.root.server.config.border_width);
+    const output_box = view.output.getEffectiveResolution();
     switch (direction) {
         .up => view.pending.box.y = border_width,
         .down => view.pending.box.y =
@@ -91,10 +90,9 @@ pub fn resize(
     const orientation = std.meta.stringToEnum(Orientation, args[1]) orelse
         return Error.InvalidOrientation;
 
-    const view = get_view(seat) orelse return;
-    const output_box = get_output_dimensions(view);
     const view = getView(seat) orelse return;
     const border_width = @intCast(i32, view.output.root.server.config.border_width);
+    const output_box = view.output.getEffectiveResolution();
     switch (orientation) {
         .horizontal => {
             var real_delta: i32 = @intCast(i32, view.pending.box.width);
@@ -158,21 +156,8 @@ fn getView(seat: *Seat) ?*View {
     return view;
 }
 
-fn get_output_dimensions(view: *View) Box {
-    var output_width: c_int = undefined;
-    var output_height: c_int = undefined;
-    c.wlr_output_effective_resolution(view.output.wlr_output, &output_width, &output_height);
-    const box: Box = .{
-        .x = 0,
-        .y = 0,
-        .width = @intCast(u32, output_width),
-        .height = @intCast(u32, output_height),
-    };
-    return box;
-}
-
 fn moveVertical(view: *View, delta: i32) void {
-    const output_box = view.output.get_output_dimensions(view);
+    const output_box = view.output.getEffectiveResolution();
     const border_width = @intCast(i32, view.output.root.server.config.border_width);
     view.pending.box.y = std.math.clamp(
         view.pending.box.y + delta,
@@ -182,7 +167,7 @@ fn moveVertical(view: *View, delta: i32) void {
 }
 
 fn moveHorizontal(view: *View, delta: i32) void {
-    const output_box = view.output.get_output_dimensions(view);
+    const output_box = view.output.getEffectiveResolution();
     const border_width = @intCast(i32, view.output.root.server.config.border_width);
     view.pending.box.x = std.math.clamp(
         view.pending.box.x + delta,


### PR DESCRIPTION
This PR introduces ~~two~~ *three* simple commands to move and resize views via the keyboard.

* `move {up,down,left,right} <delta>` to move a view by `delta` in the specified direction.

* `snap {up,down,left,right}` to snap a view to the specified screen edge.

* `resize {horizontal,vertical} <delta>` to resize a view by `delta` in the specified orientation.

Since all three actions remove the view from the layout, the view will be set to floating.

---

In the default config, moving is `Super+Alt+{h,j,k,l}` and snapping is `Super+Alt+Control+{h,j,k,l}`. Resizing ~~which I'll implement sometime in the future will be~~ *is* `Super+Alt+Shift+{h,j,k,l}`.

Went ahead and implemented resizing as well. Works like it does in sway: The views center remains stationary.

All three operations will not allow the view to escape the output, exactly like when moving with the moose. Resizing respects view constraint.