### PR TITLE
Implement XDG Toplevel move and resize requests.

### DIFF
--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -33,7 +33,7 @@ const Seat = @import("Seat.zig");
 const View = @import("View.zig");
 const ViewStack = @import("view_stack.zig").ViewStack;
 
-const Mode = union(enum) {
+pub const Mode = union(enum) {
     passthrough: void,
     down: *View,
     move: *View,

--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -45,7 +45,7 @@ const Mode = union(enum) {
     },
 
     /// Enter move or resize mode
-    fn enter(self: *Self, mode: @TagType(Mode), event: *c.wlr_event_pointer_button, view: *View) void {
+    pub fn enter(self: *Self, mode: @TagType(Mode), view: *View) void {
         log.debug(.cursor, "enter {} mode", .{@tagName(mode)});
 
         self.seat.focus(view);
@@ -418,7 +418,7 @@ fn handleButton(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) void {
                 // handled we are done here
                 if (self.handlePointerMapping(event, view)) return;
                 // Otherwise enter cursor down mode
-                Mode.enter(self, .down, event, view);
+                Mode.enter(self, .down, view);
             }
         }
 
@@ -443,8 +443,8 @@ fn handlePointerMapping(self: *Self, event: *c.wlr_event_pointer_button, view: *
     return for (config.modes.items[self.seat.mode_id].pointer_mappings.items) |mapping| {
         if (event.button == mapping.event_code and modifiers == mapping.modifiers) {
             switch (mapping.action) {
-                .move => if (!fullscreen) Mode.enter(self, .move, event, view),
-                .resize => if (!fullscreen) Mode.enter(self, .resize, event, view),
+                .move => if (!fullscreen) Mode.enter(self, .move, view),
+                .resize => if (!fullscreen) Mode.enter(self, .resize, view),
             }
             break true;
         }

--- a/river/XdgToplevel.zig
+++ b/river/XdgToplevel.zig
@@ -24,7 +24,6 @@ const log = @import("log.zig");
 const util = @import("util.zig");
 
 const Box = @import("Box.zig");
-const Mode = @import("Cursor.zig").Mode;
 const Seat = @import("Seat.zig");
 const View = @import("View.zig");
 const ViewStack = @import("view_stack.zig").ViewStack;
@@ -312,7 +311,7 @@ fn handleRequestMove(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) voi
     const self = @fieldParentPtr(Self, "listen_request_move", listener.?);
     const event = util.voidCast(c.wlr_xdg_toplevel_move_event, data.?);
     const seat = util.voidCast(Seat, event.seat.*.seat.*.data.?);
-    Mode.enter(&seat.cursor, .move, self.view);
+    seat.cursor.enterMode(.move, self.view);
 }
 
 /// Called when the client asks to be resized via the cursor.
@@ -320,5 +319,5 @@ fn handleRequestResize(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) v
     const self = @fieldParentPtr(Self, "listen_request_resize", listener.?);
     const event = util.voidCast(c.wlr_xdg_toplevel_resize_event, data.?);
     const seat = util.voidCast(Seat, event.seat.*.seat.*.data.?);
-    Mode.enter(&seat.cursor, .resize, self.view);
+    seat.cursor.enterMode(.resize, self.view);
 }


### PR DESCRIPTION
Pretty simple patch, since the code that does the actual work is already there, it just needs to be called. Using `Cursor.Mode` is a bit awkward though, since its `self` wants a `Cursor`.