### PR TITLE
Bugfix: Update view.float_box when setting a floating view to fullscreen

### DIFF
--- a/river/View.zig
+++ b/river/View.zig
@@ -171,7 +171,8 @@ pub fn applyPending(self: *Self) void {
         arrange_output = true;
 
     // If switching from float to something else save the dimensions
-    if (self.current.float and !self.pending.float)
+    if ((self.current.float and !self.pending.float) or
+        (self.current.float and !self.current.fullscreen and self.pending.fullscreen))
         self.float_box = self.current.box;
 
     // If switching from something else to float restore the dimensions


### PR DESCRIPTION
Currently,  if a floating view is moved via the mouse, then enters fullscreen, then leaves fullscreen, it returns to its original, pre-move, position/dimensions. This fixes that.