### PR TITLE
Some mapping things.

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -153,8 +153,7 @@ that tag 1 through 9 are visible.
 	_key_ is an XKB key name. See _/usr/include/xkbcommon/xkbcommon-keysyms.h_
 	for a list of special key names. _command_ can be any of the above commands.
 
-	A mapping without modifiers can be created by passing an empty string as
-	the modifiers argument.
+	A mapping without modifiers can be created by using "None" as sole modifier.
 
 *map-pointer* _mode_ _modifiers_ _button_ _action_
 	_mode_ and _modifiers_ are the same as for *map*.

--- a/river/command/map.zig
+++ b/river/command/map.zig
@@ -29,7 +29,7 @@ const modifier_names = [_]struct {
     name: []const u8,
     modifier: u32,
 }{
-    .{ .name = "", .modifier = 0 },
+    .{ .name = "None", .modifier = 0 },
     .{ .name = "Shift", .modifier = c.WLR_MODIFIER_SHIFT },
     .{ .name = "Lock", .modifier = c.WLR_MODIFIER_CAPS },
     .{ .name = "Control", .modifier = c.WLR_MODIFIER_CTRL },


### PR DESCRIPTION
**First patch:** This adds the possibility to use the modifier string "None" (evals to 0) to create mappings without modifiers. This is simply more user friendly then the current way of doing this.

---

**Second patch:** This removes the map checking for translated keysyms. I am pretty sure the raw keysyms cover every possible mapping, so it's simply not necessary.