### PR TITLE
Mapping.zig: Save allocator in struct

### DIFF
--- a/river/Mapping.zig
+++ b/river/Mapping.zig
@@ -20,6 +20,7 @@ const Self = @This();
 const std = @import("std");
 
 const c = @import("c.zig");
+const util = @import("util.zig");
 
 keysym: c.xkb_keysym_t,
 modifiers: u32,
@@ -29,12 +30,12 @@ command_args: []const []const u8,
 release: bool,
 
 pub fn init(
-    allocator: *std.mem.Allocator,
     keysym: c.xkb_keysym_t,
     modifiers: u32,
     release: bool,
     command_args: []const []const u8,
 ) !Self {
+    const allocator = util.gpa;
     const owned_args = try allocator.alloc([]u8, command_args.len);
     errdefer allocator.free(owned_args);
     for (command_args) |arg, i| {
@@ -49,7 +50,8 @@ pub fn init(
     };
 }
 
-pub fn deinit(self: Self, allocator: *std.mem.Allocator) void {
+pub fn deinit(self: Self) void {
+    const allocator = util.gpa;
     for (self.command_args) |arg| allocator.free(arg);
     allocator.free(self.command_args);
 }

--- a/river/Mode.zig
+++ b/river/Mode.zig
@@ -35,7 +35,7 @@ pub fn init() Self {
 }
 
 pub fn deinit(self: Self) void {
-    for (self.mappings.items) |m| m.deinit(util.gpa);
+    for (self.mappings.items) |m| m.deinit();
     self.mappings.deinit();
     self.pointer_mappings.deinit();
 }

--- a/river/command/map.zig
+++ b/river/command/map.zig
@@ -84,7 +84,7 @@ pub fn map(
         }
     }
 
-    try mode_mappings.append(try Mapping.init(util.gpa, keysym, modifiers, optionals.release, args[4 + offset ..]));
+    try mode_mappings.append(try Mapping.init(keysym, modifiers, optionals.release, args[4 + offset ..]));
 }
 
 /// Create a new pointer mapping for a given mode


### PR DESCRIPTION
Is there a reason why the allocator is not saved in the struct?
Right now it would be possible to call `deinit` with another allocator than the one used for `init` which would result in undefined behavior.