### PR TITLE
Implement wlr-output-power-management-unstable-v1 protocol

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -153,6 +153,7 @@ const ScanProtocolsStep = struct {
         const protocol_dir_paths = [_][]const []const u8{
             &[_][]const u8{ protocol_dir, "stable/xdg-shell/xdg-shell.xml" },
             &[_][]const u8{ "protocol", "wlr-layer-shell-unstable-v1.xml" },
+            &[_][]const u8{ "protocol", "wlr-output-power-management-unstable-v1.xml" },
             &[_][]const u8{ "protocol", "river-control-unstable-v1.xml" },
             &[_][]const u8{ "protocol", "river-status-unstable-v1.xml" },
         };
@@ -160,6 +161,7 @@ const ScanProtocolsStep = struct {
         const server_protocols = [_][]const u8{
             "xdg-shell",
             "wlr-layer-shell-unstable-v1",
+            "wlr-output-power-management-unstable-v1",
             "river-control-unstable-v1",
             "river-status-unstable-v1",
         };

--- a/protocol/wlr-output-power-management-unstable-v1.xml
+++ b/protocol/wlr-output-power-management-unstable-v1.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_output_power_management_unstable_v1">
+  <copyright>
+    Copyright © 2019 Purism SPC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Control power management modes of outputs">
+    This protocol allows clients to control power management modes
+    of outputs that are currently part of the compositor space. The
+    intent is to allow special clients like desktop shells to power
+    down outputs when the system is idle.
+
+    To modify outputs not currently part of the compositor space see
+    wlr-output-management.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_output_power_manager_v1" version="1">
+    <description summary="manager to create per-output power management">
+      This interface is a manager that allows creating per-output power
+      management mode controls.
+    </description>
+
+    <request name="get_output_power">
+      <description summary="get a power management for an output">
+        Create an output power management mode control that can be used to
+        adjust the power management mode for a given output.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_power_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_power_v1" version="1">
+    <description summary="adjust power management mode for an output">
+      This object offers requests to set the power management mode of
+      an output.
+    </description>
+
+    <enum name="mode">
+      <entry name="off" value="0"
+             summary="Output is turned off."/>
+      <entry name="on" value="1"
+             summary="Output is turned on, no power saving"/>
+    </enum>
+
+    <enum name="error">
+      <entry name="invalid_mode" value="1" summary="nonexistent power save mode"/>
+    </enum>
+
+    <request name="set_mode">
+      <description summary="Set an outputs power save mode">
+        Set an output's power save mode to the given mode. The mode change
+        is effective immediately. If the output does not support the given
+        mode a failed event is sent.
+      </description>
+      <arg name="mode" type="uint" enum="mode" summary="the power save mode to set"/>
+    </request>
+
+    <event name="mode">
+      <description summary="Report a power management mode change">
+        Report the power management mode change of an output.
+
+        The mode event is sent after an output changed its power
+        management mode. The reason can be a client using set_mode or the
+        compositor deciding to change an output's mode.
+        This event is also sent immediately when the object is created
+        so the client is informed about the current power management mode.
+      </description>
+      <arg name="mode" type="uint" enum="mode"
+           summary="the output's new power management mode"/>
+    </event>
+
+    <event name="failed">
+      <description summary="object no longer valid">
+        This event indicates that the output power management mode control
+        is no longer valid. This can happen for a number of reasons,
+        including:
+        - The output doesn't support power management
+        - Another client already has exclusive power management mode control
+          for this output
+        - The output disappeared
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this power management">
+        Destroys the output power management mode control object.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/river/Output.zig
+++ b/river/Output.zig
@@ -2,6 +2,7 @@
 //
 // Copyright 2020 Isaac Freund
 // Copyright 2020 Leon Henrik Plickat
+// Copyright 2020 Marten Ringwelski
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -600,6 +601,11 @@ fn handleFrame(listener: ?*c.wl_listener, data: ?*c_void) callconv(.C) void {
     // This function is called every time an output is ready to display a frame,
     // generally at the output's refresh rate (e.g. 60Hz).
     const self = @fieldParentPtr(Self, "listen_frame", listener.?);
+
+    // TODO(wlroots) Remove this check when we update wlroots 0.11 to 0.12
+    // wlroots fix: https://github.com/swaywm/wlroots/commit/85757665e6e1393773b36282aa244feb10b7a5fe
+    if (!self.wlr_output.enabled) return;
+
     render.renderOutput(self);
 }
 

--- a/river/c.zig
+++ b/river/c.zig
@@ -47,6 +47,7 @@ pub usingnamespace @cImport({
     @cInclude("wlr/types/wlr_matrix.h");
     @cInclude("wlr/types/wlr_output.h");
     @cInclude("wlr/types/wlr_output_layout.h");
+    @cInclude("wlr/types/wlr_output_power_management_v1.h");
     @cInclude("wlr/types/wlr_pointer.h");
     @cInclude("wlr/types/wlr_primary_selection.h");
     @cInclude("wlr/types/wlr_primary_selection_v1.h");

--- a/river/render.zig
+++ b/river/render.zig
@@ -19,6 +19,7 @@ const build_options = @import("build_options");
 const std = @import("std");
 
 const c = @import("c.zig");
+const log = @import("log.zig");
 const util = @import("util.zig");
 
 const Box = @import("Box.zig");
@@ -119,7 +120,9 @@ pub fn renderOutput(output: *Output) void {
     // on-screen.
     c.wlr_renderer_end(wlr_renderer);
     // TODO: handle failure
-    _ = c.wlr_output_commit(output.wlr_output);
+    if (!c.wlr_output_commit(output.wlr_output)) {
+        log.err(.render, "wlr_output_commit failed for {}", .{output.wlr_output.name});
+    }
 }
 
 fn renderFilter(view: *View, filter_tags: u32) bool {


### PR DESCRIPTION
This is my first protocol implementation of any kind.

I need help with one little thing which is that when disabling and enabling afterwards I get an error.
Can you point me to anything I should investigate?
```
info: (server) initializing
debug: (server) new output eDP-1
debug: (server) new output DP-1
info: (server) running...
debug: (server) new xdg_toplevel
debug: (server) view 'Alacritty' mapped
debug: (transaction) started transaction with 1 pending configure(s)
debug: (server) Disabling dmps for output eDP-1
00:00:08.531 [ERROR] [types/wlr_output.c:567] Basic output test failed
debug: (server) Enabling dmps for output eDP-1
info: (server) shutting down
debug: (server) output 'eDP-1' destroyed
debug: (server) output 'DP-1' destroyed
```

For reference here is sways code: https://github.com/swaywm/sway/blob/0cb9282aeebddeed0b5259f153f98a45311053a5/sway/desktop/output.c#L1036

For testing I hacked together a little wayland client which will turn off the first output it finds and will turn it back on three seconds later. https://git.sr.ht/~maringuu/wlr-dpms

Edit: It seems that I "try to commit a buffer to a disabled output"