### PR TITLE
Remove most of the hack which works around @cImport and flexible arrays

### DIFF
--- a/include/bindings.c
+++ b/include/bindings.c
@@ -1,7 +1,5 @@
 #define WLR_USE_UNSTABLE
 #include <wlr/backend.h>
-#include <wlr/backend/noop.h>
-#include <wlr/backend/multi.h>
 #include <wlr/render/wlr_renderer.h>
 
 struct wlr_backend *river_wlr_backend_autocreate(struct wl_display *display) {
@@ -10,32 +8,4 @@ struct wlr_backend *river_wlr_backend_autocreate(struct wl_display *display) {
 
 struct wlr_renderer *river_wlr_backend_get_renderer(struct wlr_backend *backend) {
     return wlr_backend_get_renderer(backend);
-}
-
-bool river_wlr_backend_start(struct wlr_backend *backend) {
-    return wlr_backend_start(backend);
-}
-
-bool river_wlr_backend_is_multi(struct wlr_backend *backend) {
-    return wlr_backend_is_multi(backend);
-}
-
-struct wlr_session *river_wlr_backend_get_session(struct wlr_backend *backend) {
-    return wlr_backend_get_session(backend);
-}
-
-struct wlr_backend *river_wlr_noop_backend_create(struct wl_display *display) {
-    return wlr_noop_backend_create(display);
-}
-
-struct wlr_output *river_wlr_noop_add_output(struct wlr_backend *backend) {
-    return wlr_noop_add_output(backend);
-}
-
-bool river_wlr_output_is_noop(struct wlr_output *output) {
-    return wlr_output_is_noop(output);
-}
-
-void river_wlr_backend_destory(struct wlr_backend *backend) {
-    wlr_backend_destroy(backend);
 }

--- a/include/bindings.h
+++ b/include/bindings.h
@@ -8,29 +8,7 @@
  * See https://github.com/ziglang/zig/issues/4775
  */
 
-struct wlr_backend_impl;
-
-struct wlr_backend {
-	const struct wlr_backend_impl *impl;
-
-	struct {
-		/** Raised when destroyed, passed the wlr_backend reference */
-		struct wl_signal destroy;
-		/** Raised when new inputs are added, passed the wlr_input_device */
-		struct wl_signal new_input;
-		/** Raised when new outputs are added, passed the wlr_output */
-		struct wl_signal new_output;
-	} events;
-};
-
 struct wlr_backend *river_wlr_backend_autocreate(struct wl_display *display);
 struct wlr_renderer *river_wlr_backend_get_renderer(struct wlr_backend *backend);
-bool river_wlr_backend_start(struct wlr_backend *backend);
-bool river_wlr_backend_is_multi(struct wlr_backend *backend);
-struct wlr_session *river_wlr_backend_get_session(struct wlr_backend *backend);
-struct wlr_backend *river_wlr_noop_backend_create(struct wl_display *display);
-struct wlr_output *river_wlr_noop_add_output(struct wlr_backend *backend);
-bool river_wlr_output_is_noop(struct wlr_output *output);
-void river_wlr_backend_destory(struct wlr_backend *backend);
 
 #endif // RIVER_BINDINGS_H

--- a/river/Keyboard.zig
+++ b/river/Keyboard.zig
@@ -164,8 +164,8 @@ fn handleBuiltinMapping(self: Self, keysym: c.xkb_keysym_t) bool {
     if (keysym >= c.XKB_KEY_XF86Switch_VT_1 and keysym <= c.XKB_KEY_XF86Switch_VT_12) {
         log.debug(.keyboard, "switch VT keysym received", .{});
         const wlr_backend = self.seat.input_manager.server.wlr_backend;
-        if (c.river_wlr_backend_is_multi(wlr_backend)) {
-            if (c.river_wlr_backend_get_session(wlr_backend)) |session| {
+        if (c.wlr_backend_is_multi(wlr_backend)) {
+            if (c.wlr_backend_get_session(wlr_backend)) |session| {
                 const vt = keysym - c.XKB_KEY_XF86Switch_VT_1 + 1;
                 log.notice(.server, "switching to VT {}", .{vt});
                 _ = c.wlr_session_change_vt(session, vt);

--- a/river/Output.zig
+++ b/river/Output.zig
@@ -111,7 +111,7 @@ pub fn init(self: *Self, root: *Root, wlr_output: *c.wlr_output) !void {
     self.listen_mode.notify = handleMode;
     c.wl_signal_add(&wlr_output.events.mode, &self.listen_mode);
 
-    if (c.river_wlr_output_is_noop(wlr_output)) {
+    if (c.wlr_output_is_noop(wlr_output)) {
         // A noop output is always 0 x 0
         self.usable_box = .{
             .x = 0,
@@ -146,7 +146,7 @@ pub fn init(self: *Self, root: *Root, wlr_output: *c.wlr_output) !void {
 }
 
 pub fn getRenderer(self: Self) *c.wlr_renderer {
-    return c.river_wlr_backend_get_renderer(self.wlr_output.backend);
+    return c.wlr_backend_get_renderer(self.wlr_output.backend);
 }
 
 pub fn sendViewTags(self: Self) void {

--- a/river/Root.zig
+++ b/river/Root.zig
@@ -72,7 +72,7 @@ pub fn init(self: *Self, server: *Server) !void {
         .noop_output = undefined,
     };
 
-    const noop_wlr_output = c.river_wlr_noop_add_output(server.noop_backend) orelse return error.OutOfMemory;
+    const noop_wlr_output = c.wlr_noop_add_output(server.noop_backend) orelse return error.OutOfMemory;
     try self.noop_output.init(self, noop_wlr_output);
 }
 

--- a/river/Server.zig
+++ b/river/Server.zig
@@ -85,13 +85,13 @@ pub fn init(self: *Self) !void {
 
     // This backend is used to create a noop output for use when no actual
     // outputs are available. This frees itself when the wl_display is destroyed.
-    self.noop_backend = c.river_wlr_noop_backend_create(self.wl_display) orelse
+    self.noop_backend = c.wlr_noop_backend_create(self.wl_display) orelse
         return error.OutOfMemory;
 
     // If we don't provide a renderer, autocreate makes a GLES2 renderer for us.
     // The renderer is responsible for defining the various pixel formats it
     // supports for shared memory, this configures that for clients.
-    const wlr_renderer = c.river_wlr_backend_get_renderer(self.wlr_backend).?;
+    const wlr_renderer = c.wlr_backend_get_renderer(self.wlr_backend).?;
     if (!c.wlr_renderer_init_wl_display(wlr_renderer, self.wl_display)) return error.DisplayInitFailed;
 
     self.listen_new_output.notify = handleNewOutput;
@@ -154,7 +154,7 @@ pub fn deinit(self: *Self) void {
     self.root.deinit();
 
     c.wl_display_destroy(self.wl_display);
-    c.river_wlr_backend_destory(self.noop_backend);
+    c.wlr_backend_destroy(self.noop_backend);
 
     self.input_manager.deinit();
     self.config.deinit();
@@ -163,7 +163,7 @@ pub fn deinit(self: *Self) void {
 /// Create the socket, start the backend, and setup the environment
 pub fn start(self: Self) !void {
     const socket = c.wl_display_add_socket_auto(self.wl_display) orelse return error.AddSocketError;
-    if (!c.river_wlr_backend_start(self.wlr_backend)) return error.StartBackendError;
+    if (!c.wlr_backend_start(self.wlr_backend)) return error.StartBackendError;
     if (c.setenv("WAYLAND_DISPLAY", socket, 1) < 0) return error.SetenvError;
     if (build_options.xwayland) {
         if (c.setenv("DISPLAY", self.wlr_xwayland.display_name, 1) < 0) return error.SetenvError;

--- a/river/c.zig
+++ b/river/c.zig
@@ -27,7 +27,9 @@ pub usingnamespace @cImport({
     @cInclude("libevdev/libevdev.h");
 
     @cInclude("wayland-server-core.h");
-    //@cInclude("wlr/backend.h");
+    @cInclude("wlr/backend.h");
+    @cInclude("wlr/backend/multi.h");
+    @cInclude("wlr/backend/noop.h");
     //@cInclude("wlr/render/wlr_renderer.h");
     @cInclude("wlr/types/wlr_buffer.h");
     @cInclude("wlr/types/wlr_compositor.h");


### PR DESCRIPTION
While working on implementing the virtual pointer protocol, I noticed that most of the hack is not needed.

The problem is the `wlr/render/wlr_renderer.h`.
None of  `wlr/backend.h`, `wlr/backend/noop.h` and `wlr/backend/multi.h` include `wlr/render/wlr_renderer.h` so it should be safe to `@cInclude` them and remove the wrapper functions.