### PR TITLE
code: Move wlr_output_layout_add from Output.init to Root.addOutput

### DIFF
--- a/river/Output.zig
+++ b/river/Output.zig
@@ -121,12 +121,6 @@ pub fn init(self: *Self, root: *Root, wlr_output: *c.wlr_output) !void {
             .height = 0,
         };
     } else {
-        // Add the new output to the layout. The add_auto function arranges outputs
-        // from left-to-right in the order they appear. A more sophisticated
-        // compositor would let the user configure the arrangement of outputs in the
-        // layout. This automatically creates an output global on the wl_display.
-        c.wlr_output_layout_add_auto(root.wlr_output_layout, wlr_output);
-
         // Ensure that a cursor image at the output's scale factor is loaded
         // for each seat.
         var it = root.server.input_manager.seats.first;

--- a/river/Root.zig
+++ b/river/Root.zig
@@ -102,6 +102,12 @@ pub fn addOutput(self: *Self, wlr_output: *c.wlr_output) void {
     };
     self.outputs.append(node);
 
+    // Add the new output to the layout. The add_auto function arranges outputs
+    // from left-to-right in the order they appear. A more sophisticated
+    // compositor would let the user configure the arrangement of outputs in the
+    // layout. This automatically creates an output global on the wl_display.
+    c.wlr_output_layout_add_auto(self.wlr_output_layout, wlr_output);
+
     // if we previously had no real outputs, move focus from the noop output
     // to the new one.
     if (self.outputs.len == 1) {


### PR DESCRIPTION
This is needed for my upcoming PR to implement `wlr_output_management_unstable_v1` (Which should be opened tomorrow).
I'm not quite sure if my argumentation is right so feel free to ignore this until I opend the PR for output management.

The difference this PR makes is that now we can listen to `wlr_output_layout.change` and whenever this change is the addition of an output we now can be sure that the output is a fully initialized member of `Root.outputs`.

Currently the output is added to `Root.outputs` only after it is added to the `wlr_output_layout` which makes it hard for me to iterate over all outputs.
While typing I this noticed that I could also iterate over `wlr_output_layout.outputs`. But this feels wrong to me.

Also this introduces some some duplication of the call to `wlr_output_layout_add_auto` because it now needs to be called manually. Imo this is fine since the noop_output is a special case anyway.

What are your thoughts?