### PR TITLE
Repeat Rate Command

### DIFF
--- a/contrib/config.sh
+++ b/contrib/config.sh
@@ -128,6 +128,9 @@ do
 	riverctl map "${mode}" None XF86MonBrightnessDown spawn light -U 5
 done
 
+# Set repeat rate
+riverctl set-repeat 50 300
+
 # Set the layout on startup
 riverctl layout rivertile left
 

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -196,6 +196,9 @@ that tag 1 through 9 are visible.
 *outer-padding* _pixels_
 	Set the padding around the edge of the screen to _pixels_.
 
+*set-repeat* _rate_ _delay_
+	Set the keyboard repeat rate to _rate_ and repeat delay to _delay_.
+
 *unmap* [-release] _mode_ _modifiers_ _key_
 	Removes the mapping defined by the arguments *-release*, *modifiers* and *key* from *mode*.
 	See *map* for an explanation of the arguments.

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -197,7 +197,8 @@ that tag 1 through 9 are visible.
 	Set the padding around the edge of the screen to _pixels_.
 
 *set-repeat* _rate_ _delay_
-	Set the keyboard repeat rate to _rate_ and repeat delay to _delay_.
+	Set the keyboard repeat rate to _rate_ key repeats per second and
+	repeat delay to _delay_ milliseconds.
 
 *unmap* [-release] _mode_ _modifiers_ _key_
 	Removes the mapping defined by the arguments *-release*, *modifiers* and *key* from *mode*.

--- a/river/command.zig
+++ b/river/command.zig
@@ -67,6 +67,7 @@ const str_to_impl_fn = [_]struct {
     .{ .name = "resize",                 .impl = @import("command/move.zig").resize },
     .{ .name = "send-to-output",         .impl = @import("command/send_to_output.zig").sendToOutput },
     .{ .name = "set-focused-tags",       .impl = @import("command/tags.zig").setFocusedTags },
+    .{ .name = "set-repeat",             .impl = @import("command/set_repeat.zig").setRepeat },
     .{ .name = "set-view-tags",          .impl = @import("command/tags.zig").setViewTags },
     .{ .name = "snap",                   .impl = @import("command/move.zig").snap },
     .{ .name = "spawn",                  .impl = @import("command/spawn.zig").spawn },

--- a/river/command/set_repeat.zig
+++ b/river/command/set_repeat.zig
@@ -1,6 +1,6 @@
 // This file is part of river, a dynamic tiling wayland compositor.
 //
-// Copyright 2020 Isaac Freund
+// Copyright 2020 Bonicgamer
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -22,7 +22,7 @@ const c = @import("../c.zig");
 const Error = @import("../command.zig").Error;
 const Seat = @import("../Seat.zig");
 
-/// Close the focused view, if any.
+/// Set the repeat rate and delay for all keyboards.
 pub fn setRepeat(
     allocator: *std.mem.Allocator,
     seat: *Seat,
@@ -35,6 +35,8 @@ pub fn setRepeat(
     const rate = try std.fmt.parseInt(i32, args[1], 10);
     const delay = try std.fmt.parseInt(i32, args[2], 10);
 
-    const keyboard: *c.wlr_keyboard = c.wlr_seat_get_keyboard(seat.wlr_seat);
-    c.wlr_keyboard_set_repeat_info(keyboard, rate, delay);
+    var it = seat.keyboards.first;
+    while (it) |node| : (it = node.next) {
+        c.wlr_keyboard_set_repeat_info(node.data.wlr_keyboard, rate, delay);
+    }
 }

--- a/river/command/set_repeat.zig
+++ b/river/command/set_repeat.zig
@@ -1,6 +1,6 @@
 // This file is part of river, a dynamic tiling wayland compositor.
 //
-// Copyright 2020 Bonicgamer
+// Copyright 2020 The River Developers
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/river/command/set_repeat.zig
+++ b/river/command/set_repeat.zig
@@ -1,0 +1,40 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2020 Isaac Freund
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+
+const c = @import("../c.zig");
+
+const Error = @import("../command.zig").Error;
+const Seat = @import("../Seat.zig");
+
+/// Close the focused view, if any.
+pub fn setRepeat(
+    allocator: *std.mem.Allocator,
+    seat: *Seat,
+    args: []const []const u8,
+    out: *?[]const u8,
+) Error!void {
+    if (args.len < 3) return Error.NotEnoughArguments;
+    if (args.len > 3) return Error.TooManyArguments;
+
+    const rate = try std.fmt.parseInt(i32, args[1], 10);
+    const delay = try std.fmt.parseInt(i32, args[2], 10);
+
+    const keyboard: *c.wlr_keyboard = c.wlr_seat_get_keyboard(seat.wlr_seat);
+    c.wlr_keyboard_set_repeat_info(keyboard, rate, delay);
+}


### PR DESCRIPTION
This adds a 'set-repeat' command which sets the repeat rate and delay.

Most of the code is copied from River itself (not Sway this time), but one day I promise I'm going to make something without coping code.

Closes #70