### PR TITLE
focus-follow-cursor: Change output focus when needed

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -136,9 +136,12 @@ that tag 1 through 9 are visible.
 *focus-follows-cursor* *disabled*|*normal*|*strict*
 	When _disabled_ moving the cursor will not influence the focus. This is the default setting.
 	If set to _normal_ moving the cursor over a window will focus that window.
-	The focus still can be changed and moving the cursor within the (now unfocused) window will not change the focus to that window
-	but let the currently focused window in focus.
+	The focus still can be changed and moving the cursor within the (now unfocused) window will
+	not change the focus to that window but let the currently focused window in focus.
 	When set to _strict_ this is not the case. The focus will be updated on every cursor movement.
+
+	When the to be focused view is on another output than the currently focused output the view's
+	output is focused.
 
 *map* [-release] _mode_ _modifiers_ _key_ _command_
 	_mode_ is either "normal" (the default mode), "locked" (the mode entered when

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -242,6 +242,8 @@ pub fn setFocusRaw(self: *Self, new_focus: FocusTarget) void {
 
 /// Focus the given output, notifying any listening clients of the change.
 pub fn focusOutput(self: *Self, output: *Output) void {
+    if (self.focused_output == output) return;
+
     const root = &self.input_manager.server.root;
 
     var it = self.status_trackers.first;


### PR DESCRIPTION
I think this is the expected behavior. I added a note in the man page to make it clear.

Also I simplified the code.