### PR TITLE
command: Implement spawn-tagmask

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -104,6 +104,8 @@ take a normal base 10 number as their argument but the semantics are best
 understood in binary. The binary number 000000001 represents a set containing
 only tag 1 while 100001101 represents a set containing tags 1, 3, 4, and 9.
 
+When a view spawns it will be assigned the currently focused tags.
+
 At least one tag must always be focused and each view must be assigned at
 least one tag. Operations that would violate either of these requirements
 are ignored by river.
@@ -115,6 +117,13 @@ are ignored by river.
 *set-view-tags* _tags_
 	Assign the currently focused view the tags corresponding to the set
 	bits of _tags_.
+
+*spawn-tagmask* _tagmask_
+	Specify a _tagmask_ to filter the tags assigned to a newly spawned view.
+	E.g. when 000011111 is focused and _tagmask_ is 111110000 a view will
+	be assigned 000010000.
+	When no tags would remain after filtering the _tagmask_ is ignored.
+
 
 *toggle-focused-tags* _tags_
 	Toggle visibility of views with tags corresponding to the set bits

--- a/river/Output.zig
+++ b/river/Output.zig
@@ -73,6 +73,9 @@ layout: []const u8,
 /// Determines where new views will be attached to the view stack.
 attach_mode: AttachMode = .top,
 
+/// Bitmask that whitelists tags for newly spawned views
+spawn_tagmask: u32 = (1 << 32) - 1,
+
 /// List of status tracking objects relaying changes to this output to clients.
 status_trackers: std.SinglyLinkedList(OutputStatus) = .{},
 

--- a/river/Server.zig
+++ b/river/Server.zig
@@ -177,7 +177,7 @@ fn handleNewXdgSurface(listener: *wl.Listener(*wlr.XdgSurface), xdg_surface: *wl
         xdg_surface.resource.postNoMemory();
         return;
     };
-    node.view.init(output, output.current.tags, xdg_surface);
+    node.view.init(output, getNewViewTags(output), xdg_surface);
 }
 
 /// This event is raised when the layer_shell recieves a new surface from a client.
@@ -247,5 +247,10 @@ fn handleNewXwaylandSurface(listener: *wl.Listener(*wlr.XwaylandSurface), wlr_xw
     // The View will add itself to the output's view stack on map
     const output = self.input_manager.defaultSeat().focused_output;
     const node = util.gpa.create(ViewStack(View).Node) catch return;
-    node.view.init(output, output.current.tags, wlr_xwayland_surface);
+    node.view.init(output, getNewViewTags(output), wlr_xwayland_surface);
+}
+
+fn getNewViewTags(output: *Output) u32 {
+    const tags = output.current.tags & output.spawn_tagmask;
+    return if (tags != 0) tags else output.current.tags;
 }

--- a/river/command.zig
+++ b/river/command.zig
@@ -71,6 +71,7 @@ const str_to_impl_fn = [_]struct {
     .{ .name = "set-view-tags",          .impl = @import("command/tags.zig").setViewTags },
     .{ .name = "snap",                   .impl = @import("command/move.zig").snap },
     .{ .name = "spawn",                  .impl = @import("command/spawn.zig").spawn },
+    .{ .name = "spawn-tagmask",          .impl = @import("command/tags.zig").spawnTagmask },
     .{ .name = "swap",                   .impl = @import("command/swap.zig").swap},
     .{ .name = "toggle-float",           .impl = @import("command/toggle_float.zig").toggleFloat },
     .{ .name = "toggle-focused-tags",    .impl = @import("command/tags.zig").toggleFocusedTags },

--- a/river/command/tags.zig
+++ b/river/command/tags.zig
@@ -36,6 +36,17 @@ pub fn setFocusedTags(
     }
 }
 
+/// Set the view tag blacklist
+pub fn spawnTagmask(
+    allocator: *std.mem.Allocator,
+    seat: *Seat,
+    args: []const []const u8,
+    out: *?[]const u8,
+) Error!void {
+    const tags = try parseTags(allocator, args, out);
+    seat.focused_output.spawn_tagmask = tags;
+}
+
 /// Set the tags of the focused view.
 pub fn setViewTags(
     allocator: *std.mem.Allocator,


### PR DESCRIPTION
I find it quite useful to be able to filter out some tags when an new view is opened.
My primary usecase is to have scratchpad like behaviour.


Closes #169 