### PR TITLE
riverctl: implement river-options interface

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -40,6 +40,7 @@ pub fn build(b: *zbs.Builder) !void {
 
     const scanner = ScanProtocolsStep.create(b);
     scanner.addSystemProtocol("stable/xdg-shell/xdg-shell.xml");
+    scanner.addSystemProtocol("unstable/xdg-output/xdg-output-unstable-v1.xml");
     scanner.addProtocolPath("protocol/river-control-unstable-v1.xml");
     scanner.addProtocolPath("protocol/river-options-unstable-v1.xml");
     scanner.addProtocolPath("protocol/river-status-unstable-v1.xml");

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -280,6 +280,25 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 	and is made available through the _XCURSOR_THEME_ and _XCURSOR_SIZE_
 	environment variables.
 
+# OPTIONS
+
+River has various options that are saved in a typed key-value store. It also
+allows users to store arbitrary custom options in the store. Options are
+scoped either globally or per-output if the -output flag is passed with the
+name of the output as obtained from the xdg-output protocol.
+
+*declare-option* [-output _output_name_] _name_ _type_ _value_
+	Declare a new option with the given _type_ and inital _value_. If
+	the option already exists with the given _type_, it is still set
+	to _value_. If the option already exists with a different type,
+	nothing happens.
+
+*get-option* [-output _output_name_] _name_
+	Print the current value of the given option to stdout.
+
+*set-option* [-output _output_name_] _name_ _value_
+	Set the value of the specified option to _value_.
+
 # EXAMPLES
 
 Bind bemenu-run to Super+P in normal mode:

--- a/riverctl/args.zig
+++ b/riverctl/args.zig
@@ -1,0 +1,115 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2021 The River Developers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const mem = std.mem;
+const cstr = std.cstr;
+
+const root = @import("root");
+
+pub const FlagDef = struct {
+    name: [*:0]const u8,
+    kind: enum { boolean, arg },
+};
+
+pub fn Args(comptime num_positionals: comptime_int, comptime flag_defs: []const FlagDef) type {
+    return struct {
+        const Self = @This();
+
+        positionals: [num_positionals][*:0]const u8,
+        flags: [flag_defs.len]struct {
+            name: [*:0]const u8,
+            value: union {
+                boolean: bool,
+                arg: ?[*:0]const u8,
+            },
+        },
+
+        pub fn parse(argv: [][*:0]const u8) Self {
+            var ret: Self = undefined;
+
+            // Init all flags in the flags array to false/null
+            inline for (flag_defs) |flag_def, flag_idx| {
+                switch (flag_def.kind) {
+                    .boolean => ret.flags[flag_idx] = .{
+                        .name = flag_def.name,
+                        .value = .{ .boolean = false },
+                    },
+                    .arg => ret.flags[flag_idx] = .{
+                        .name = flag_def.name,
+                        .value = .{ .arg = null },
+                    },
+                }
+            }
+
+            // Parse the argv in to the positionals and flags arrays
+            var arg_idx: usize = 0;
+            var positional_idx: usize = 0;
+            outer: while (arg_idx < argv.len) : (arg_idx += 1) {
+                inline for (flag_defs) |flag_def, flag_idx| {
+                    if (cstr.cmp(flag_def.name, argv[arg_idx]) == 0) {
+                        switch (flag_def.kind) {
+                            .boolean => ret.flags[flag_idx].value.boolean = true,
+                            .arg => {
+                                arg_idx += 1;
+                                ret.flags[flag_idx].value.arg = if (arg_idx < argv.len)
+                                    argv[arg_idx]
+                                else
+                                    root.printErrorExit("flag '" ++ flag_def.name ++
+                                        "' requires an argument but none was provided!", .{});
+                            },
+                        }
+                        continue :outer;
+                    }
+                }
+
+                if (positional_idx == num_positionals) {
+                    root.printErrorExit(
+                        "{} positional arguments expected but more were provided!",
+                        .{num_positionals},
+                    );
+                }
+
+                ret.positionals[positional_idx] = argv[arg_idx];
+                positional_idx += 1;
+            }
+
+            if (positional_idx < num_positionals) {
+                root.printErrorExit(
+                    "{} positional arguments expected but only {} were provided!",
+                    .{ num_positionals, positional_idx },
+                );
+            }
+
+            return ret;
+        }
+
+        pub fn boolFlag(self: Self, flag_name: [*:0]const u8) bool {
+            for (self.flags) |flag| {
+                if (cstr.cmp(flag.name, flag_name) == 0) return flag.value.boolean;
+            }
+            unreachable;
+        }
+
+        pub fn argFlag(self: Self, flag_name: [*:0]const u8) ?[*:0]const u8 {
+            for (self.flags) |flag| {
+                if (cstr.cmp(flag.name, flag_name) == 0) return flag.value.arg;
+            }
+            unreachable;
+        }
+    };
+}

--- a/riverctl/options.zig
+++ b/riverctl/options.zig
@@ -1,0 +1,187 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2021 The River Developers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const os = std.os;
+const mem = std.mem;
+const fmt = std.fmt;
+
+const wayland = @import("wayland");
+const wl = wayland.client.wl;
+const zriver = wayland.client.zriver;
+const zxdg = wayland.client.zxdg;
+
+const root = @import("root");
+
+const Args = @import("args.zig").Args;
+const FlagDef = @import("args.zig").FlagDef;
+const Globals = @import("main.zig").Globals;
+const Output = @import("main.zig").Output;
+
+const ValueType = enum {
+    int,
+    uint,
+    fixed,
+    string,
+};
+
+const Context = struct {
+    display: *wl.Display,
+    key: [*:0]const u8,
+    raw_value: [*:0]const u8,
+    output: ?*Output,
+};
+
+pub fn declareOption(display: *wl.Display, globals: *Globals) !void {
+    // https://github.com/ziglang/zig/issues/7807
+    const argv: [][*:0]const u8 = os.argv;
+    const args = Args(3, &[_]FlagDef{.{ .name = "-output", .kind = .arg }}).parse(argv[2..]);
+    const key = args.positionals[0];
+    const value_type = std.meta.stringToEnum(ValueType, mem.span(args.positionals[1])) orelse
+        root.printErrorExit("'{}' is not a valid type, must be int, uint, fixed, or string", .{args.positionals[1]});
+    const raw_value = args.positionals[2];
+    const output = if (args.argFlag("-output")) |o| try parseOutputName(display, globals, o) else null;
+
+    const options_manager = globals.options_manager orelse return error.RiverOptionsManagerNotAdvertised;
+    const handle = try options_manager.getOptionHandle(key, if (output) |o| o.wl_output else null);
+
+    switch (value_type) {
+        .int => setIntValueRaw(handle, raw_value),
+        .uint => setUintValueRaw(handle, raw_value),
+        .fixed => setFixedValueRaw(handle, raw_value),
+        .string => handle.setStringValue(raw_value),
+    }
+    _ = display.flush() catch os.exit(1);
+}
+
+fn setIntValueRaw(handle: *zriver.OptionHandleV1, raw_value: [*:0]const u8) void {
+    handle.setIntValue(fmt.parseInt(i32, mem.span(raw_value), 10) catch
+        root.printErrorExit("{} is not a valid int", .{raw_value}));
+}
+
+fn setUintValueRaw(handle: *zriver.OptionHandleV1, raw_value: [*:0]const u8) void {
+    handle.setUintValue(fmt.parseInt(u32, mem.span(raw_value), 10) catch
+        root.printErrorExit("{} is not a valid uint", .{raw_value}));
+}
+
+fn setFixedValueRaw(handle: *zriver.OptionHandleV1, raw_value: [*:0]const u8) void {
+    handle.setFixedValue(wl.Fixed.fromDouble(fmt.parseFloat(f64, mem.span(raw_value)) catch
+        root.printErrorExit("{} is not a valid fixed", .{raw_value})));
+}
+
+pub fn getOption(display: *wl.Display, globals: *Globals) !void {
+    // https://github.com/ziglang/zig/issues/7807
+    const argv: [][*:0]const u8 = os.argv;
+    const args = Args(1, &[_]FlagDef{.{ .name = "-output", .kind = .arg }}).parse(argv[2..]);
+    const ctx = Context{
+        .display = display,
+        .key = args.positionals[0],
+        .raw_value = undefined,
+        .output = if (args.argFlag("-output")) |o| try parseOutputName(display, globals, o) else null,
+    };
+
+    const options_manager = globals.options_manager orelse return error.RiverOptionsManagerNotAdvertised;
+    const handle = try options_manager.getOptionHandle(ctx.key, if (ctx.output) |o| o.wl_output else null);
+    handle.setListener(*const Context, getOptionListener, &ctx) catch unreachable;
+
+    // We always exit when our listener is called
+    while (true) _ = try display.dispatch();
+}
+
+pub fn setOption(display: *wl.Display, globals: *Globals) !void {
+    // https://github.com/ziglang/zig/issues/7807
+    const argv: [][*:0]const u8 = os.argv;
+    const args = Args(2, &[_]FlagDef{.{ .name = "-output", .kind = .arg }}).parse(argv[2..]);
+    const ctx = Context{
+        .display = display,
+        .key = args.positionals[0],
+        .raw_value = args.positionals[1],
+        .output = if (args.argFlag("-output")) |o| try parseOutputName(display, globals, o) else null,
+    };
+
+    const options_manager = globals.options_manager orelse return error.RiverOptionsManagerNotAdvertised;
+    const handle = try options_manager.getOptionHandle(ctx.key, if (ctx.output) |o| o.wl_output else null);
+    handle.setListener(*const Context, setOptionListener, &ctx) catch unreachable;
+
+    // We always exit when our listener is called
+    while (true) _ = try display.dispatch();
+}
+
+fn parseOutputName(display: *wl.Display, globals: *Globals, output_name: [*:0]const u8) !*Output {
+    const output_manager = globals.output_manager orelse return error.XdgOutputNotAdvertised;
+    for (globals.outputs.items) |*output| {
+        const xdg_output = try output_manager.getXdgOutput(output.wl_output);
+        xdg_output.setListener(*Output, xdgOutputListener, output) catch unreachable;
+    }
+    _ = try display.roundtrip();
+
+    for (globals.outputs.items) |*output| {
+        if (mem.eql(u8, output.name, mem.span(output_name))) return output;
+    }
+    root.printErrorExit("unknown output '{}'", .{output_name});
+}
+
+fn xdgOutputListener(xdg_output: *zxdg.OutputV1, event: zxdg.OutputV1.Event, output: *Output) void {
+    switch (event) {
+        .name => |ev| output.name = std.heap.c_allocator.dupe(u8, mem.span(ev.name)) catch @panic("out of memory"),
+        else => {},
+    }
+}
+
+fn getOptionListener(
+    handle: *zriver.OptionHandleV1,
+    event: zriver.OptionHandleV1.Event,
+    ctx: *const Context,
+) void {
+    switch (event) {
+        .unset => if (ctx.output) |output| {
+            root.printErrorExit("option '{}' has not been declared on output '{}'", .{ ctx.key, output.name });
+        } else {
+            root.printErrorExit("option '{}' has not been declared globally", .{ctx.key});
+        },
+        .int_value => |ev| printOutputExit("{}", .{ev.value}),
+        .uint_value => |ev| printOutputExit("{}", .{ev.value}),
+        .fixed_value => |ev| printOutputExit("{d}", .{ev.value.toDouble()}),
+        .string_value => |ev| printOutputExit("{}", .{ev.value}),
+    }
+}
+
+fn printOutputExit(comptime format: []const u8, args: anytype) noreturn {
+    const stdout = std.io.getStdOut().writer();
+    stdout.print(format ++ "\n", args) catch os.exit(1);
+    os.exit(0);
+}
+
+fn setOptionListener(
+    handle: *zriver.OptionHandleV1,
+    event: zriver.OptionHandleV1.Event,
+    ctx: *const Context,
+) void {
+    switch (event) {
+        .unset => if (ctx.output) |output| {
+            root.printErrorExit("option '{}' has not been declared on output '{}'", .{ ctx.key, output.name });
+        } else {
+            root.printErrorExit("option '{}' has not been declared globally", .{ctx.key});
+        },
+        .int_value => |ev| setIntValueRaw(handle, ctx.raw_value),
+        .uint_value => |ev| setUintValueRaw(handle, ctx.raw_value),
+        .fixed_value => |ev| setFixedValueRaw(handle, ctx.raw_value),
+        .string_value => |ev| handle.setStringValue(ctx.raw_value),
+    }
+    _ = ctx.display.flush() catch os.exit(1);
+    os.exit(0);
+}


### PR DESCRIPTION
To make this cleaner, introduce some arg-parsing infrastructure that
will useful when porting riverctl to river-control-v2 in the future as
well.