### PR TITLE
Add output-title default option

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -299,6 +299,12 @@ name of the output as obtained from the xdg-output protocol.
 *set-option* [-output _output_name_] _name_ _value_
 	Set the value of the specified option to _value_.
 
+River declares certain default options for all outputs.
+
+*output-title* (string)
+	Changing this option changes the title of the wayland and X11 backend
+	outputs.
+
 # EXAMPLES
 
 Bind bemenu-run to Super+P in normal mode:

--- a/river/Server.zig
+++ b/river/Server.zig
@@ -112,12 +112,12 @@ pub fn init(self: *Self) !void {
 
     self.config = try Config.init();
     try self.decoration_manager.init(self);
+    try self.options_manager.init(self);
     try self.root.init(self);
     // Must be called after root is initialized
     try self.input_manager.init(self);
     try self.control.init(self);
     try self.status_manager.init(self);
-    try self.options_manager.init(self);
 
     // These all free themselves when the wl_server is destroyed
     _ = try wlr.DataDeviceManager.create(self.wl_server);


### PR DESCRIPTION
Outputs now have a default option, "output-title". If this changes, the
outputs title is set to the option value.

---

Also lays the ground-work for any later default options.