### PR TITLE
swap: use correct direction for it_wrap

### DIFF
--- a/river/command/swap.zig
+++ b/river/command/swap.zig
@@ -51,7 +51,7 @@ pub fn swap(
     );
     var it_wrap = ViewStack(View).iter(
         if (direction == .next) output.views.first else output.views.last,
-        .forward,
+        if (direction == .next) .forward else .reverse,
         output.pending.tags,
         filter,
     );


### PR DESCRIPTION
Always using `.forward` results in a crash when running `swap previous` on the first view in stack which should be wrapped.

Stack trace from gdb before this fix when trying to `swap previous`:

```
attempt to use null value
/home/alex/repos/river/river/command/swap.zig:66:55: 0x21b435 in command.swap.swap (river)
        if (it.next()) |next| next else it_wrap.next().?,
                                                      ^
/home/alex/repos/river/river/command.zig:125:16: 0x24cd7d in command.run (river)
    try impl_fn(allocator, seat, args, out);
               ^
/home/alex/repos/river/river/Control.zig:101:24: 0x239666 in Control.handleRequest (river)
            command.run(util.gpa, seat, args, &out) catch |err| {
                       ^
/home/alex/repos/river/zig-cache/zig-wayland/common.zig:101:76: 0x24d8f1 in .wayland.common.Dispatcher(.wayland.zriver_control_v1_server.ControlV1,*Control).dispatcher (river)
                    @ptrCast(fn (*Obj, Payload, Data) void, implementation)(
                                                                           ^

Thread 1 "river" received signal SIGABRT, Aborted.
```