### PR TITLE
Add distance threshold for move/resize request of tiled XDG toplevels

### DIFF
--- a/river/XdgToplevel.zig
+++ b/river/XdgToplevel.zig
@@ -296,14 +296,14 @@ fn handleRequestMove(
 ) void {
     const self = @fieldParentPtr(Self, "request_move", listener);
     const seat = @intToPtr(*Seat, event.seat.seat.data);
-    seat.cursor.enterMode(.move, self.view);
+    seat.cursor.enterMode(if (self.view.pending.float) .move else .moveThreshold, self.view);
 }
 
 /// Called when the client asks to be resized via the cursor.
 fn handleRequestResize(listener: *wl.Listener(*wlr.XdgToplevel.event.Resize), event: *wlr.XdgToplevel.event.Resize) void {
     const self = @fieldParentPtr(Self, "request_resize", listener);
     const seat = @intToPtr(*Seat, event.seat.seat.data);
-    seat.cursor.enterMode(.resize, self.view);
+    seat.cursor.enterMode(if (self.view.pending.float) .resize else .resizeThreshold, self.view);
 }
 
 /// Called when the client sets / updates its title


### PR DESCRIPTION
Back when I implemented move/resize requests for XDG toplevel I also accidentally introduced a now pretty common and annoying issue: Views immediately enter the move/resize mode and were therefore are set to floating when the request is made, which would interfere with normal usage (example: clicking anywhere in the mpv window and it will immediately start floating).

This patch  introduces an arbitrary threshold before the requested move/resize mode is entered. This is only the case for tiled views; Floating views will enter the mode immediately. The issue mentioned above is solved by this addition.

This is indeed yet another topic where a "client-side vs server-side" discussion could ignite, but the current state is that there is only one client-side implementation of such a threshold I am aware of (GTK header bars). All other clients leave it up to the server. This means GTK header bars now have two thresholds, the CS and SS one, but since both are small and we only apply the SS one for tiled views it is not really noticeable, so I am personally fine with it. We could also make our SS threshold smaller if need be.

FWIW kwin apparently also has a threshold for "snapped" views, although theirs appears to be much smaller.