### PR TITLE
Added installation through nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ zig build -Drelease-safe --prefix /usr install
 ```
 To enable experimental Xwayland support pass the `-Dxwayland` option as well.
 
+## Install from package manager
+Currently river is available in [nixpkgs](https://github.com/NixOS/nixpkgs) for Nix package manager users which follow **nixpkgs-master** channel.
+
+*Note: river in nixpkgs is prebuild with manpages and xwayland support*
+```
+nix-env -iA nixpkgs.river
+```
+
 ## Usage
 
 River can either be run nested in an X11/wayland session or directly


### PR DESCRIPTION
Hello, since river is now part of nixpkgs repo which is official channel for NixOS and non-nixos users, just added little update to readme on how to install prebuild package from nix. River from master branch was merged today and now it's available as binary cache according to [this](https://github.com/NixOS/nixpkgs/pull/119387) pull request. I'm having acces to this derivation so river will be always even with master branch (excluding small edits like fix typos etc.).