### PR TITLE
example/init: Fix typos in introductory comment and keybindings

### DIFF
--- a/example/init
+++ b/example/init
@@ -42,11 +42,11 @@ riverctl map normal $mod Return zoom
 
 # Mod+H and Mod+L to decrease/increase the main_factor value of rivertile by 0.05
 riverctl map normal $mod H mod-layout-value rivertile fixed main_factor -0.05
-riverctl map normal $mod I mod-layout-value rivertile fixed main_factor +0.05
+riverctl map normal $mod L mod-layout-value rivertile fixed main_factor +0.05
 
 # Mod+Shift+H and Mod+Shift+L to increment/decrement the main_count value of rivertile.
 riverctl map normal $mod+Shift H mod-layout-value rivertile int main_count +1
-riverctl map normal $mod+Shift I mod-layout-value rivertile int main_count -1
+riverctl map normal $mod+Shift L mod-layout-value rivertile int main_count -1
 
 # Mod+Alt+{H,J,K,L} to move views
 riverctl map normal $mod+Mod1 H move left 100

--- a/example/init
+++ b/example/init
@@ -5,7 +5,7 @@
 # If you wish to edit this, you will probably want to copy it to
 # $XDG_CONFIG_HOME/river/init or $HOME/.config/river/init first.
 #
-# See the river(1), riverctl(1), and river(1) man pages for complete
+# See the river(1), riverctl(1), and rivertile(1) man pages for complete
 # documentation.
 
 # Use the "logo" key as the primary modifier


### PR DESCRIPTION
A typo in the init file uses `I` instead of `L` to increase the size of main_factor and main_count. This PR changes the occurances of `I` back to `L`.

Based on git history and the comments in example/init (and the behaviour of dwm), I am assuming `L` is the intended key.
