### PR TITLE
Allow changing output focus with pointer

### DIFF
--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -123,10 +123,14 @@ pub fn focus(self: *Self, _target: ?*View) void {
     // While a layer surface is focused, views may not recieve focus
     if (self.focused == .layer) return;
 
-    // If the view is not currently visible, behave as if null was passed
     if (target) |view| {
-        if (view.output != self.focused_output or
-            view.pending.tags & self.focused_output.pending.tags == 0) target = null;
+        // If the view is not currently visible, behave as if null was passed
+        if (view.pending.tags & view.output.pending.tags == 0) {
+            target = null;
+        } else {
+            // If the view is not on the currently focused output, focus it
+            if (view.output != self.focused_output) self.focusOutput(view.output);
+        }
     }
 
     // If the target view is not fullscreen or null, then a fullscreen view


### PR DESCRIPTION
This patch makes it possible to use the pointer to focus views on an unfocused output.

TODO: Clicking on an empty desktop should also change focus.