### PR TITLE
completions/zsh: add input commands

### DIFF
--- a/completions/zsh/_riverctl
+++ b/completions/zsh/_riverctl
@@ -1,90 +1,147 @@
 #compdef riverctl
+#
+# Completion script for riverctl, part of river <https://github.com/ifreund/river>
 
+_riverctl_subcommands()
+{
+    local -a riverctl_subcommands
 
-_riverctl() {
+    riverctl_subcommands=(
+        # Actions
+        'close:Close the focused view'
+        'csd-filter-add:Add app-id to the CSD filter list'
+        'exit:Exit the compositor, terminating the Wayland session'
+        'float-filter-add:Add app-id to the float filter list'
+        'focus-output:Focus the next or previous output'
+        'focus-view:Focus the next or previous view in the stack'
+        'move:Move the focused view in the specified direction'
+        'resize:Resize the focused view along the given axis'
+        'snap:Snap the focused view to the specified screen edge'
+        'send-to-output:Send the focused view to the next or the previous output'
+        'spawn:Run shell_command using /bin/sh -c'
+        'swap:Swap the focused view with the next/previous visible non-floating view'
+        'toggle-float:Toggle the floating state of the focused view'
+        'toggle-fullscreen:Toggle the fullscreen state of the focused view'
+        'zoom:Bump the focused view to the top of the layout stack'
+        'default-layout:Set the layout namespace to be used by all outputs by default.'
+        'output-layout:Set the layout namespace of currently focused output.'
+        'set-layout-value:Set the value with name _name_ of the layout on the focused output with matching namespace.'
+        'mod-layout-value:Modify the value with name _name_ of the layout on the focused output with matching namespace.'
+        # Tag management
+        'set-focused-tags:Show views with tags corresponding to the set bits of tags'
+        'set-view-tags:Assign the currently focused view the tags corresponding to the set bits of tags'
+        'toggle-focused-tags:Toggle visibility of views with tags corresponding to the set bits of tags'
+        'toggle-view-tags:Toggle the tags of the currently focused view'
+        'spawn-tagmask:Set a tagmask to filter the tags assigned to newly spawned views on the focused output'
+        # Mappings
+        'declare-mode:Create a new mode'
+        'enter-mode:Switch to given mode if it exists'
+        'map:Run command when key is pressed while modifiers are held down and in the specified mode'
+        'map-pointer:Move or resize views when button and modifiers are held down while in the specified mode'
+        'unmap:Remove the mapping defined by the arguments'
+        'unmap-pointer:Remove the pointer mapping defined by the arguments'
+        # Configuration
+        'attach-mode:Configure where new views should attach to the view stack'
+        'background-color:Set the background color'
+        'border-color-focused:Set the border color of focused views'
+        'border-color-unfocused:Set the border color of unfocused views'
+        'border-width:Set the border width to pixels'
+        'focus-follows-cursor:Configure the focus behavior when moving cursor'
+        'opacity:Configure server-side opacity of views'
+        'set-repeat:Set the keyboard repeat rate and repeat delay'
+        'xcursor-theme:Set the xcursor theme'
+        # Input
+        'input:Configure input devices'
+        'list-inputs:List all input devices'
+        'list-input-configs:List all input configurations'
+    )
 
-  _next_prev() { _alternative 'arguments:args:(next previous)' }
-  _orientations() { _alternative 'arguments:args:(up down left right)' }
-  _hor_ver() { _alternative 'arguments:args:(horizontal vertical)' }
-  _attach() { _alternative 'arguments:args:(top bottom)' }
-  _focus_cursor() { _alternative 'arguments:args:(disabled normal strict)' }
-  _river_opts() { _alternative 'arguments:args:(-output -focused-output)' }
-
-  local -a _cmds
-
-  _cmds=(
-    # Actions
-    'close:Close the focused view'
-    'csd-filter-add:Add app-id to the CSD filter list'
-    'exit:Exit the compositor, terminating the Wayland session'
-    'float-filter-add:Add app-id to the float filter list'
-    'focus-output:Focus the next or previous output'
-    'focus-view:Focus the next or previous view in the stack'
-    'move:Move the focused view in the specified direction'
-    'resize:Resize the focused view along the given axis'
-    'snap:Snap the focused view to the specified screen edge'
-    'send-to-output:Send the focused view to the next or the previous output'
-    'spawn:Run shell_command using /bin/sh -c'
-    'swap:Swap the focused view with the next/previous visible non-floating view'
-    'toggle-float:Toggle the floating state of the focused view'
-    'toggle-fullscreen:Toggle the fullscreen state of the focused view'
-    'zoom:Bump the focused view to the top of the layout stack'
-    'default-layout:Set the layout namespace to be used by all outputs by default.'
-    'output-layout:Set the layout namespace of currently focused output.'
-    'set-layout-value:Set the value with name _name_ of the layout on the focused output with matching namespace.'
-    'mod-layout-value:Modify the value with name _name_ of the layout on the focused output with matching namespace.'
-    # Tag management
-    'set-focused-tags:Show views with tags corresponding to the set bits of tags'
-    'set-view-tags:Assign the currently focused view the tags corresponding to the set bits of tags'
-    'toggle-focused-tags:Toggle visibility of views with tags corresponding to the set bits of tags'
-    'toggle-view-tags:Toggle the tags of the currently focused view'
-    'spawn-tagmask:Set a tagmask to filter the tags assigned to newly spawned views on the focused output'
-    # Mappings
-    'declare-mode:Create a new mode'
-    'enter-mode:Switch to given mode if it exists'
-    'map:Run command when key is pressed while modifiers are held down and in the specified mode'
-    'map-pointer:Move or resize views when button and modifiers are held down while in the specified mode'
-    'unmap:Remove the mapping defined by the arguments'
-    'unmap-pointer:Remove the pointer mapping defined by the arguments'
-    # Configuration
-    'attach-mode:Configure where new views should attach to the view stack'
-    'background-color:Set the background color'
-    'border-color-focused:Set the border color of focused views'
-    'border-color-unfocused:Set the border color of unfocused views'
-    'border-width:Set the border width to pixels'
-    'focus-follows-cursor:Configure the focus behavior when moving cursor'
-    'opacity:Configure server-side opacity of views'
-    'set-repeat:Set the keyboard repeat rate and repeat delay'
-    'xcursor-theme:Set the xcursor theme'
-  )
-
-  local -A opt_args
-
-  _arguments -C '*:: :->_cmds'
-
-  if (( CURRENT == 1 )); then
-    _describe -t commands "commands" _cmds
-    return
-  fi
-
-  case "$words[1]" in
-    focus-output) _next_prev ;;
-    focus-view) _next_prev ;;
-    move) _orientations ;;
-    resize) _hor_ver ;;
-    snap) _orientations ;;
-    send-to-output) _next_prev ;;
-    swap) _next_prev ;;
-    map) _alternative 'arguments:optional:(-release)' ;;
-    unmap) _alternative 'arguments:optional:(-release)' ;;
-    attach-mode) _attach ;;
-    focus-follows-cursor) _focus_cursor ;;
-    get-option) _river_opts ;;
-    set-option) _river_opts ;;
-    unset-option) _river_opts ;;
-    mod-option) _river_opts ;;
-    *) return 0 ;;
-  esac
-
-  return 1
+    _describe -t command 'command' riverctl_subcommands
 }
+
+_riverctl_input_subcommands()
+{
+    local -a input_subcommands
+
+    input_subcommands=(
+        'events:Configure whether the input devices events will be used by river'
+        'accel-profile:Set the pointer acceleration profile'
+        'pointer-accel:Set the pointer acceleration factor'
+        'click-method:Set the click method'
+        'drag:Enable or disable the tap-and-drag functionality'
+        'drag-lock:Enable or disable the drag lock functionality'
+        'disable-while-typing:Enable or disable the disable-while-typing functionality'
+        'middle-emulation:Enable or disable the middle click emulation functionality'
+        'natural-scroll:Enable or disable the natural scroll functionality'
+        'left-handed:Enable or disable the left handed mode'
+        'tap:Enable or disable the tap functionality'
+        'tap-button-map:Configure the button mapping for tapping'
+        'scroll-method:Set the scroll method'
+        'scroll-button:Set the scroll button'
+    )
+
+    _describe -t command 'command' input_subcommands
+}
+
+_riverctl_input()
+{
+    local state
+
+    _arguments \
+        '1: :->commands' \
+        '*:: :->args'
+
+    case $state in
+        commands) _alternative 'common-commands:common:_riverctl_input_subcommands' ;;
+        args)
+            case "$words[1]" in
+                events) _alternative 'input-cmds:args:(enabled disabled disabled-on-external-mouse)' ;;
+                accel-profile) _alternative 'input-cmds:args:(none flat adaptive)' ;;
+                click-method) _alternative 'input-cmds:args:(none button-area clickfinger)' ;;
+                drag) _alternative 'input-cmds:args:(enabled disabled)' ;;
+                drag-lock) _alternative 'input-cmds:args:(enabled disabled)' ;;
+                disable-while-typing) _alternative 'input-cmds:args:(enabled disabled)' ;;
+                middle-emulation) _alternative 'input-cmds:args:(enabled disabled)' ;;
+                natural-scroll) _alternative 'input-cmds:args:(enabled disabled)' ;;
+                left-handed) _alternative 'input-cmds:args:(enabled disabled)' ;;
+                tap) _alternative 'input-cmds:args:(enabled disabled)' ;;
+                tap-button-map) _alternative 'input-cmds:args:(left-right-middle left-middle-right)' ;;
+                scroll-method) _alternative 'input-cmds:args:(none two-finger edge button)' ;;
+                *) return 0 ;;
+            esac
+        ;;
+    esac
+}
+
+_riverctl()
+{
+    local state
+
+    _arguments \
+        '1: :->commands' \
+        '*:: :->args'
+
+    case $state in
+        commands) _alternative 'common-commands:common:_riverctl_subcommands' ;;
+        args)
+            case "$words[1]" in
+                focus-output) _alternative 'arguments:args:(next previous)' ;;
+                focus-view) _alternative 'arguments:args:(next previous)' ;;
+                input) _riverctl_input ;;
+                move) _alternative 'arguments:args:(up down left right)' ;;
+                resize) _alternative 'arguments:args:(horizontal vertical)' ;;
+                snap) _alternative 'arguments:args:(up down left right)' ;;
+                send-to-output) _alternative 'arguments:args:(next previous)' ;;
+                swap) _alternative 'arguments:args:(next previous)' ;;
+                map) _alternative 'arguments:optional:(-release)' ;;
+                unmap) _alternative 'arguments:optional:(-release)' ;;
+                attach-mode) _alternative 'arguments:args:(top bottom)' ;;
+                focus-follows-cursor) _alternative 'arguments:args:(disabled normal strict)' ;;
+                *) return 0 ;;
+            esac
+        ;;
+    esac
+}
+
+_riverctl "$@"
+


### PR DESCRIPTION
Cleanup a bit too

Feel like the script is a little hacky, but as far as I understand `_arguments` only works with args like `-c |--commands` so I need to use `_alternative`, a bit redundant 