### PR TITLE
layer-shell: handle commits before map

### DIFF
--- a/river/InputManager.zig
+++ b/river/InputManager.zig
@@ -220,7 +220,7 @@ fn handleInhibitDeactivate(
     // keyboard-interactive surfaces will re-grab focus.
     var output_it = server.root.outputs.first;
     while (output_it) |output_node| : (output_it = output_node.next) {
-        output_node.data.arrangeLayers();
+        output_node.data.arrangeLayers(.mapped);
     }
 
     // After ensuring that any possible layer surface focus grab has occured,

--- a/river/Root.zig
+++ b/river/Root.zig
@@ -490,7 +490,7 @@ fn applyOutputConfig(self: *Self, config: *wlr.OutputConfigurationV1) bool {
         // Arrange layers to adjust the usable_box
         // We dont need to call arrangeViews() since arrangeLayers() will call
         // it for us because the usable_box changed
-        output.arrangeLayers();
+        output.arrangeLayers(.mapped);
         self.startTransaction();
     }
 


### PR DESCRIPTION
A client is free to change its mind and request a different
size/anchor/etc after recieving the initial configure but before
attaching and committing the first buffer. This means that we should
respond to such a situation with a new configure.

mako has been observed doing this in the wild for example.

closes #226