### PR TITLE
completions: typo

### DIFF
--- a/completions/bash/riverctl
+++ b/completions/bash/riverctl
@@ -40,7 +40,7 @@ function __riverctl_completion ()
 			border-color-focused \
 			border-color-unfocused \
 			border-width \
-			focus-follow-cursor \
+			focus-follows-cursor \
 			opacity \
 			set-repeat \
 			set-cursor-warp \


### PR DESCRIPTION
Hello,

I noticed a typo in the bash completions while configuring river.

Thank you for the compositor!