### PR TITLE
Fix typo in rivertile doc/manual

### DIFF
--- a/doc/rivertile.1.scd
+++ b/doc/rivertile.1.scd
@@ -55,7 +55,7 @@ These commands may be sent to rivertile at runtime with the help of
 	_value_ is prefixed by a +/- sign, _value_ is added/subtracted from the
 	current count. If there is no sign, the main count is set to _value_.
 
-*main-count* _value_
+*main-ratio* _value_
 	Set or modify the ratio of the main area to total layout area. If
 	_value_ is prefixed by a +/- sign, _value_ is added/subtracted from
 	the current ratio. If there is no sign, the main ratio is set to


### PR DESCRIPTION
Basically, renames the duplicated `main-count` to the correct `main-ratio`, according to the command's description.