### PR TITLE
build: Use pkg-config to handle river protocols

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -124,7 +124,26 @@ pub fn build(b: *zbs.Builder) !void {
         rivertile.install();
     }
 
-    b.installFile("protocol/river-layout-v3.xml", "share/river/river-layout-v3.xml");
+    {
+        const file = try fs.path.join(b.allocator, &[_][]const u8{ b.cache_root, "river-protocols.pc" });
+        const pkgconfig_file = try std.fs.cwd().createFile(file, .{});
+
+        const writer = pkgconfig_file.writer();
+        try writer.print(
+            \\prefix={s}
+            \\datadir=${{prefix}}/share
+            \\pkgdatadir=${{datadir}}/river-protocols
+            \\
+            \\Name: river-protocols
+            \\URL: https://github.com/ifreund/river
+            \\Description: protocol files for the river wayland compositor
+            \\Version: {s}
+        , .{ b.install_prefix, full_version });
+        defer pkgconfig_file.close();
+
+        b.installFile("protocol/river-layout-v3.xml", "share/river-protocols/river-layout-v3.xml");
+        b.installFile(file, "share/pkgconfig/river-protocols.pc");
+    }
 
     if (man_pages) {
         const scdoc_step = ScdocStep.create(b);


### PR DESCRIPTION
- Install river-layout-v3 in `$prefix/share/river-protocols/`
- Create `river-protocols.pc` in `zig-cache/` and install it in `$prefix/share/pkgconfig/`

Now for example in a 3rd party program you could use:
```zig
const std = @import("std");
const Builder = @import("std").build.Builder;

const ScanProtocolsStep = @import("deps/zig-wayland/build.zig").ScanProtocolsStep;

pub fn build(b: *Builder) !void {
    [...]
    
    const protocol_path = std.mem.trim(u8, b.exec(
        &[_][]const u8{ "pkg-config", "--variable=pkgdatadir", "river-protocols" },
    ) catch unreachable, &std.ascii.spaces);
    const layout_protocol = try std.fs.path.join(b.allocator, &[_][]const u8{protocol_path, "river-layout-v3.xml"});
    scanner.addProtocolPath(layout_protocol);
    
    [...]
}
```

I'm not sure about the version @ifreund, so tell me if you want something else