### PR TITLE
ci: add musl runner

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -22,12 +22,6 @@ jobs:
         run: |
           # wlroots dependencies as well as we build from source
           sh ~/river/.github/workflows/install_deps.sh
-
-          git clone https://github.com/swaywm/wlroots.git
-          cd wlroots
-          git checkout 0.14.0
-          meson build --auto-features=enabled -Dexamples=false -Dwerror=false -Db_ndebug=false
-          ninja -C build install
       - name: checkout
         uses: actions/checkout@v2
         with:
@@ -49,21 +43,8 @@ jobs:
     steps:
       - name: install deps
         run: |
-          xbps-install -S
-          xbps-install -uy xbps
           # wlroots dependencies as well as we build from source
-          xbps-install -uy MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
-            libinput-devel libxkbcommon-devel pixman-devel wayland-devel wayland-protocols \
-            xcb-util-errors-devel xcb-util-wm-devel xcb-util-renderutil-devel libxcb-devel \
-            xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel \
-            xcb-util-xrm-devel xorg-server-xwayland pkg-config meson git gcc \
-            zig pkgconf scdoc
-
-          git clone https://github.com/swaywm/wlroots.git
-          cd wlroots
-          git checkout 0.14.0
-          meson build --auto-features=enabled -Dexamples=false -Dwerror=false -Db_ndebug=false
-          ninja -C build install
+          sh ~/river/.github/workflows/install_deps.sh
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -20,15 +20,8 @@ jobs:
     steps:
       - name: install deps
         run: |
-          xbps-install -S
-          xbps-install -uy xbps
           # wlroots dependencies as well as we build from source
-          xbps-install -uy MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
-            libinput-devel libxkbcommon-devel pixman-devel wayland-devel wayland-protocols \
-            xcb-util-errors-devel xcb-util-wm-devel xcb-util-renderutil-devel libxcb-devel \
-            xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel \
-            xcb-util-xrm-devel xorg-server-xwayland pkg-config meson git gcc \
-            zig pkgconf scdoc
+          sh ~/river/.github/workflows/install_deps.sh
 
           git clone https://github.com/swaywm/wlroots.git
           cd wlroots

--- a/.github/workflows/ci_build_musl.yml
+++ b/.github/workflows/ci_build_musl.yml
@@ -1,0 +1,110 @@
+# Build river with rusl libc and run the test suite every time a commit is pushed to master or
+# a pull request is opened against master.
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: voidlinux-musl
+
+jobs:
+  default_build_musl:
+    name: default build on musl
+    runs-on: ubuntu-latest
+    container: voidlinux/voidlinux-musl:latest
+
+    steps:
+      - name: install deps
+        run: |
+          xbps-install -S
+          xbps-install -uy xbps
+          # wlroots dependencies as well as we build from source
+          xbps-install -uy MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
+            libinput-devel libxkbcommon-devel pixman-devel wayland-devel wayland-protocols \
+            xcb-util-errors-devel xcb-util-wm-devel xcb-util-renderutil-devel libxcb-devel \
+            xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel \
+            xcb-util-xrm-devel xorg-server-xwayland pkg-config meson git gcc \
+            zig pkgconf scdoc
+
+          git clone https://github.com/swaywm/wlroots.git
+          cd wlroots
+          git checkout 0.14.0
+          meson build --auto-features=enabled -Dexamples=false -Dwerror=false -Db_ndebug=false
+          ninja -C build install
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: build
+        run: |
+          zig build
+
+      - name: test
+        run: |
+          zig build test
+
+  xwayland_build:
+    name: xwayland build on musl
+    runs-on: ubuntu-latest
+    container: voidlinux/voidlinux-musl:latest
+
+    steps:
+      - name: install deps
+        run: |
+          xbps-install -S
+          xbps-install -uy xbps
+          # wlroots dependencies as well as we build from source
+          xbps-install -uy MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
+            libinput-devel libxkbcommon-devel pixman-devel wayland-devel wayland-protocols \
+            xcb-util-errors-devel xcb-util-wm-devel xcb-util-renderutil-devel libxcb-devel \
+            xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel \
+            xcb-util-xrm-devel xorg-server-xwayland pkg-config meson git gcc \
+            zig pkgconf scdoc
+
+          git clone https://github.com/swaywm/wlroots.git
+          cd wlroots
+          git checkout 0.14.0
+          meson build --auto-features=enabled -Dexamples=false -Dwerror=false -Db_ndebug=false
+          ninja -C build install
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: build
+        run: |
+          zig build -Dxwayland=true
+
+      - name: test
+        run: |
+          zig build -Dxwayland=true test
+
+  zig_fmt:
+    name: zig fmt on musl
+    runs-on: ubuntu-latest
+    container: voidlinux/voidlinux-musl:latest
+
+    steps:
+      - name: install deps
+        run: |
+          xbps-install -S
+          xbps-install -uy xbps
+          xbps-install -uy zig git
+
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: fmt
+        run: |
+          zig fmt --check river/
+          zig fmt --check riverctl/
+          zig fmt --check rivertile/
+          zig fmt --check example/
+          zig fmt --check build.zig

--- a/.github/workflows/ci_build_musl.yml
+++ b/.github/workflows/ci_build_musl.yml
@@ -22,12 +22,6 @@ jobs:
         run: |
           # wlroots dependencies as well as we build from source
           sh ~/river/.github/workflows/install_deps.sh
-
-          git clone https://github.com/swaywm/wlroots.git
-          cd wlroots
-          git checkout 0.14.0
-          meson build --auto-features=enabled -Dexamples=false -Dwerror=false -Db_ndebug=false
-          ninja -C build install
       - name: checkout
         uses: actions/checkout@v2
         with:
@@ -49,21 +43,8 @@ jobs:
     steps:
       - name: install deps
         run: |
-          xbps-install -S
-          xbps-install -uy xbps
           # wlroots dependencies as well as we build from source
-          xbps-install -uy MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
-            libinput-devel libxkbcommon-devel pixman-devel wayland-devel wayland-protocols \
-            xcb-util-errors-devel xcb-util-wm-devel xcb-util-renderutil-devel libxcb-devel \
-            xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel \
-            xcb-util-xrm-devel xorg-server-xwayland pkg-config meson git gcc \
-            zig pkgconf scdoc
-
-          git clone https://github.com/swaywm/wlroots.git
-          cd wlroots
-          git checkout 0.14.0
-          meson build --auto-features=enabled -Dexamples=false -Dwerror=false -Db_ndebug=false
-          ninja -C build install
+          sh ~/river/.github/workflows/install_deps.sh
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci_build_musl.yml
+++ b/.github/workflows/ci_build_musl.yml
@@ -20,15 +20,8 @@ jobs:
     steps:
       - name: install deps
         run: |
-          xbps-install -S
-          xbps-install -uy xbps
           # wlroots dependencies as well as we build from source
-          xbps-install -uy MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
-            libinput-devel libxkbcommon-devel pixman-devel wayland-devel wayland-protocols \
-            xcb-util-errors-devel xcb-util-wm-devel xcb-util-renderutil-devel libxcb-devel \
-            xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel \
-            xcb-util-xrm-devel xorg-server-xwayland pkg-config meson git gcc \
-            zig pkgconf scdoc
+          sh ~/river/.github/workflows/install_deps.sh
 
           git clone https://github.com/swaywm/wlroots.git
           cd wlroots

--- a/.github/workflows/install_deps.sh
+++ b/.github/workflows/install_deps.sh
@@ -8,3 +8,9 @@ xbps-install -uy MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
   xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel \
   xcb-util-xrm-devel xorg-server-xwayland pkg-config meson git gcc \
   zig pkgconf scdoc
+
+git clone https://github.com/swaywm/wlroots.git
+cd wlroots
+git checkout 0.14.0
+meson build --auto-features=enabled -Dexamples=false -Dwerror=false -Db_ndebug=false
+ninja -C build install

--- a/.github/workflows/install_desp.sh
+++ b/.github/workflows/install_desp.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+xbps-install -S
+xbps-install -uy xbps
+xbps-install -uy MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
+  libinput-devel libxkbcommon-devel pixman-devel wayland-devel wayland-protocols \
+  xcb-util-errors-devel xcb-util-wm-devel xcb-util-renderutil-devel libxcb-devel \
+  xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel \
+  xcb-util-xrm-devel xorg-server-xwayland pkg-config meson git gcc \
+  zig pkgconf scdoc


### PR DESCRIPTION
I'm opening this as Draft because GitHub has problems with checkout on containers with musl libc as for now (same command works locally but fails here) also aready opened issue about this in [checkout](https://github.com/actions/checkout/issues/560) repo. All what I did was copying base runner and changing container name to `voidlinux/voidlinux-msul` and adding `musl` to name of every job.

This PR partially closes this [340](https://github.com/ifreund/river/issues/340), there is no easy way to run FreeBSD in GitHub Actions, I'd tried using docker container and vm as `macos-latest` (only macOS has VMs as CI). I think easiest way would be copy of river on SourceHut because they are having FreeBSD as native system for CIs, thats the same way which Zig itself uses for tests on FreeBSD.

I'm FreeBSD user and can confirm that after switch to Zig 0.8 didn't had to add any patches to even compile it, also ports tree auto build and deploy latest commit and there is info if fails or not.