### PR TITLE
render: draw borders before rendering views

### DIFF
--- a/river/render.zig
+++ b/river/render.zig
@@ -93,32 +93,32 @@ pub fn renderOutput(output: *Output) void {
         it = ViewStack(View).iter(output.views.last, .reverse, output.current.tags, renderFilter);
         while (it.next()) |view| {
             if (view.current.focus != 0 or view.current.float) continue;
-            renderView(output, view, &now);
             if (view.draw_borders) renderBorders(output, view, &now);
+            renderView(output, view, &now);
         }
 
         // focused, non-floating views
         it = ViewStack(View).iter(output.views.last, .reverse, output.current.tags, renderFilter);
         while (it.next()) |view| {
             if (view.current.focus == 0 or view.current.float) continue;
-            renderView(output, view, &now);
             if (view.draw_borders) renderBorders(output, view, &now);
+            renderView(output, view, &now);
         }
 
         // non-focused, floating views
         it = ViewStack(View).iter(output.views.last, .reverse, output.current.tags, renderFilter);
         while (it.next()) |view| {
             if (view.current.focus != 0 or !view.current.float) continue;
-            renderView(output, view, &now);
             if (view.draw_borders) renderBorders(output, view, &now);
+            renderView(output, view, &now);
         }
 
         // focused, floating views
         it = ViewStack(View).iter(output.views.last, .reverse, output.current.tags, renderFilter);
         while (it.next()) |view| {
             if (view.current.focus == 0 or !view.current.float) continue;
-            renderView(output, view, &now);
             if (view.draw_borders) renderBorders(output, view, &now);
+            renderView(output, view, &now);
         }
 
         if (build_options.xwayland) renderXwaylandUnmanaged(output, &now);


### PR DESCRIPTION
Menus, tooltips, etc. can extend beyond a view's borders.  Render views after their borders so floating content appears on top.

Unfocused floating content can still be obscured by views higher in the stack and the focused view.

Fixes #382.