### PR TITLE
Allow float-filter-add to inspect window titles

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -41,14 +41,14 @@ over the Wayland protocol.
 *exit*
 	Exit the compositor, terminating the Wayland session.
 
-*float-filter-add* _app-id_
-	Add _app-id_ to the float filter list. Views with this _app-id_
-	will start floating. Note that this affects only new views, not already
-	existing ones.
+*float-filter-add* *app-id*|*title* _pattern_
+	Add a pattern to the float filter list. Note that this affects only new
+	views, not already existing ones. Title updates are also not taken into
+	account.
 
-*float-filter-remove* _app-id_
-	Remove an _app-id_ from the float filter list. Note that this affects only
-	new views, not already existing ones.
+*float-filter-remove* *app-id*|*title* _pattern_
+	Remove an app-id or title from the float filter list. Note that this
+	affects only new views, not already existing ones.
 
 *focus-output* *next*|*previous*|*up*|*right*|*down*|*left*
 	Focus the next or previous output or the closest output in any direction.

--- a/river/XdgToplevel.zig
+++ b/river/XdgToplevel.zig
@@ -212,15 +212,10 @@ fn handleMap(listener: *wl.Listener(*wlr.XdgSurface), xdg_surface: *wlr.XdgSurfa
         view.current.float = true;
         view.pending.float = true;
         view.pending.box = view.float_box;
-    } else {
-        // Make views with app_ids listed in the float filter float
-        if (toplevel.app_id) |app_id| {
-            if (server.config.float_filter.contains(mem.span(app_id))) {
-                view.current.float = true;
-                view.pending.float = true;
-                view.pending.box = view.float_box;
-            }
-        }
+    } else if (server.config.shouldFloat(view)) {
+        view.current.float = true;
+        view.pending.float = true;
+        view.pending.box = view.float_box;
     }
 
     // If the toplevel has an app_id which is not configured to use client side

--- a/river/XwaylandView.zig
+++ b/river/XwaylandView.zig
@@ -196,15 +196,10 @@ fn handleMap(listener: *wl.Listener(*wlr.XwaylandSurface), xwayland_surface: *wl
         view.current.float = true;
         view.pending.float = true;
         view.pending.box = view.float_box;
-    } else {
-        // Make views with app_ids listed in the float filter float
-        if (self.xwayland_surface.class) |app_id| {
-            if (server.config.float_filter.contains(std.mem.span(app_id))) {
-                view.current.float = true;
-                view.pending.float = true;
-                view.pending.box = view.float_box;
-            }
-        }
+    } else if (server.config.shouldFloat(view)) {
+        view.current.float = true;
+        view.pending.float = true;
+        view.pending.box = view.float_box;
     }
 
     view.map() catch {


### PR DESCRIPTION
This extends the float-filter-add command using a 'prefix:string_to_match' syntax. The following prefixes are supported:

  * `title`, which matches window titles
  * `app-id`, which matches app ids

If no prefix is given, then `app-id` is assumed for backwards compatibility.

As an example following configuration floats all windows with the title 'asdf with spaces'.

    riverctl float-filter-add 'title:asdf with spaces'

The syntax was briefly discussed in #289. As I understand Leon, this is intended as a small quality-of-life change for existing setups. This implementation only checks view titles on creation, not upon title changes. I wouldn't know of a usecase for the latter, so I'd say we don't implement it.

Feedback wanted :) I'm new to both wayland and zig, so don't hold back!