### PR TITLE
river: add send-to-previous-tags command

### DIFF
--- a/completions/bash/riverctl
+++ b/completions/bash/riverctl
@@ -25,6 +25,7 @@ function __riverctl_completion ()
 			send-layout-cmd \
 			set-focused-tags \
 			focus-previous-tags \
+			send-to-previous-tags \
 			set-view-tags \
 			toggle-focused-tags \
 			toggle-view-tags \

--- a/completions/fish/riverctl.fish
+++ b/completions/fish/riverctl.fish
@@ -64,6 +64,7 @@ complete -c riverctl -x -n '__fish_riverctl_complete_no_subcommand' -a toggle-fo
 complete -c riverctl -x -n '__fish_riverctl_complete_no_subcommand' -a toggle-view-tags       -d 'Toggle the tags of the currently focused view'
 complete -c riverctl -x -n '__fish_riverctl_complete_no_subcommand' -a spawn-tagmask          -d 'Set a tagmask to filter the tags assigned to newly spawned views on the focused output'
 complete -c riverctl -x -n '__fish_riverctl_complete_no_subcommand' -a focus-previous-tags    -d 'Sets tags to their previous value on the focused output'
+complete -c riverctl -x -n '__fish_riverctl_complete_no_subcommand' -a send-to-previous-tags  -d 'Assign the currently focused view the previous tags of the focused output'
 # Mappings
 complete -c riverctl -x -n '__fish_riverctl_complete_no_subcommand' -a declare-mode           -d 'Create a new mode'
 complete -c riverctl -x -n '__fish_riverctl_complete_no_subcommand' -a enter-mode             -d 'Switch to given mode if it exists'

--- a/completions/zsh/_riverctl
+++ b/completions/zsh/_riverctl
@@ -33,6 +33,7 @@ _riverctl_subcommands()
         'toggle-view-tags:Toggle the tags of the currently focused view'
         'spawn-tagmask:Set a tagmask to filter the tags assigned to newly spawned views on the focused output'
         'focus-previous-tags:Sets tags to their previous value on the focused output'
+        'send-to-previous-tags:Assign the currently focused view the previous tags of the focused output'
         # Mappings
         'declare-mode:Create a new mode'
         'enter-mode:Switch to given mode if it exists'

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -147,6 +147,10 @@ are ignored by river.
 	Sets tags to their previous value on the currently focused output,
 	allowing jumping back and forth between 2 tag setups.
 
+*send-to-previous-tags*
+	Assign the currently focused view the previous tags of the currently
+	focused output.
+
 ## MAPPINGS
 
 Mappings are modal in river. Each mapping is associated with a mode and is

--- a/river/command.zig
+++ b/river/command.zig
@@ -83,6 +83,7 @@ const str_to_impl_fn = [_]struct {
     .{ .name = "toggle-fullscreen",      .impl = @import("command/toggle_fullscreen.zig").toggleFullscreen },
     .{ .name = "toggle-view-tags",       .impl = @import("command/tags.zig").toggleViewTags },
     .{ .name = "focus-previous-tags",    .impl = @import("command/tags.zig").focusPreviousTags },
+    .{ .name = "send-to-previous-tags",  .impl = @import("command/tags.zig").sendToPreviousTags },
     .{ .name = "unmap",                  .impl = @import("command/map.zig").unmap },
     .{ .name = "unmap-pointer",          .impl = @import("command/map.zig").unmapPointer },
     .{ .name = "xcursor-theme",          .impl = @import("command/xcursor_theme.zig").xcursorTheme },

--- a/river/command/tags.zig
+++ b/river/command/tags.zig
@@ -121,6 +121,22 @@ pub fn focusPreviousTags(
     }
 }
 
+/// Set the tags of the focused view to the tags that were selected previously
+pub fn sendToPreviousTags(
+    allocator: *std.mem.Allocator,
+    seat: *Seat,
+    args: []const []const u8,
+    out: *?[]const u8,
+) Error!void {
+    const previous_tags = seat.focused_output.previous_tags;
+    if (seat.focused == .view) {
+        const view = seat.focused.view;
+        view.pending.tags = previous_tags;
+        seat.focus(null);
+        view.applyPending();
+    }
+}
+
 fn parseTags(
     allocator: *std.mem.Allocator,
     args: []const [:0]const u8,


### PR DESCRIPTION
Closes https://github.com/ifreund/river/issues/416. This isn't just for symmetry's sake, as I find that `send-to-previous-tags` really does complement `focus-previous-tags` well. `focus-previous-tags` is great because it allows you to temporarily replace the mental overhead of alternating between tags like "$mod+1, $mod+7, $mod+1..." with one repeated keystroke, but if you want to send a view to the alternate tagset you have to break out of that shortcut and recall which tags you were using. My typical use case is starting a couple of related, slow to start applications, e.g. an IDE and a SQL client, or Steam and a game, in my working tagset and sending them to the alternate tagset at they pop up.

Would it be worth adding default bindings for this and `focus-previous-tags` in the example init file? 